### PR TITLE
fix: add bounds check before memcpy in scanner.h

### DIFF
--- a/common/scanner.h
+++ b/common/scanner.h
@@ -158,6 +158,7 @@ static inline bool implicit_cf_end_tag_valid(const bool *vs, unsigned count) {
     uint16_t _count = (tags_field).size > UINT16_MAX ? UINT16_MAX : (tags_field).size; \
     uint16_t _serialized = 0; \
     unsigned _count_offset = (size); \
+    if ((size) + sizeof(_count) + sizeof(_count) > TREE_SITTER_SERIALIZATION_BUFFER_SIZE) break; \
     (size) += sizeof(_count); \
     (size) += sizeof(_count); \
     for (; _serialized < _count; _serialized++) { \


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `common/scanner.h`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `common/scanner.h:173` |

**Description**: The serialization macros in common/scanner.h write scanner state fields (html_depth, cfoutput_depth, cfcomponent_depth, cffunction_depth, tag contents) into a caller-supplied buffer using memcpy without validating that the destination buffer has sufficient remaining capacity. The 'size' variable is incremented after each write but there is no check that (size + sizeof(field)) <= buffer_capacity before writing. A crafted input that causes the scanner to accumulate many tags or deeply nested structures will cause the serialized state to exceed the buffer, writing beyond its boundary and corrupting adjacent heap memory.

## Changes
- `common/scanner.h`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
