### PR TITLE
Ignore downloaded tree-sitter CLI binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,5 @@ Thumbs.db
 *.zip
 .npmrc
 tree-sitter.exe
+/tree-sitter
 /vendor


### PR DESCRIPTION
## Summary
- `npm install` downloads the `tree-sitter` CLI binary to the repo root; the Windows `tree-sitter.exe` variant was already gitignored, but the POSIX binary wasn't, so it shows up as an untracked file after a fresh install
- Add `/tree-sitter` to `.gitignore` alongside the existing `tree-sitter.exe` entry

## Test plan
- [x] `git status` is clean after `npm install` with the binary present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ke54pcod9W3F33H7KeG8

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5ke54pcod9W3F33H7KeG8)_