### PR TITLE
Add PyPI publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,71 @@ on:
       - "v*"
 
 jobs:
+  build-wheels:
+    name: Build wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v4.1.0
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  build-sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Build sdist
+        run: |
+          python -m pip install build
+          python -m build --sdist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish-pypi:
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
   release:
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+- Publish Python bindings to PyPI as part of the release workflow (wheels built via `cibuildwheel`, sdist via `build`, upload via trusted publishing)
+- Fix Python sdist/wheel builds: bundle `common/*.h`, per-dialect `tree_sitter/*.h`, and `cfml/queries/*.scm` so `pip install tree-sitter-cfml` succeeds from source and query constants resolve
+
 ## [0.26.29]
 
 ### cfml & cfscript

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,21 @@
 3. After grammar or scanner changes, run **`npm run build`** and include updated files under each dialect’s `cf*/src/` when the change is finished.
 
 For scope or design questions, open an issue when useful.
+
+## Releasing to PyPI
+
+The `Release` workflow (`.github/workflows/release.yml`) builds wheels with `cibuildwheel`
+and an sdist with `build`, then publishes to PyPI using
+[trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC, no stored token).
+Before the first release, a PyPI project owner must register a trusted publisher for
+`tree-sitter-cfml` (new projects can do this via "pending publisher" before any upload
+has happened):
+
+- Publisher: GitHub Actions
+- Repository: `cfmleditor/tree-sitter-cfml`
+- Workflow: `release.yml`
+- Environment: `pypi`
+
+Also create a `pypi` [environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment)
+in the repo settings (optionally with required reviewers) so the `publish-pypi` job's
+`environment: pypi` matches.

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,9 @@ else:
 
 class Build(build):
     def run(self):
-        if path.isdir("queries"):
+        if path.isdir("cfml/queries"):
             dest = path.join(self.build_lib, "tree_sitter_cfml", "queries")
-            self.copy_tree("queries", dest)
+            self.copy_tree("cfml/queries", dest)
         super().run()
 
 
@@ -55,8 +55,11 @@ class BdistWheel(bdist_wheel):
 class EggInfo(egg_info):
     def find_sources(self):
         super().find_sources()
-        self.filelist.recursive_include("queries", "*.scm")
+        self.filelist.recursive_include("cfml/queries", "*.scm")
         self.filelist.include("cfml/src/tree_sitter/*.h")
+        self.filelist.include("cfscript/src/tree_sitter/*.h")
+        self.filelist.include("cfquery/src/tree_sitter/*.h")
+        self.filelist.include("common/*.h")
 
 
 setup(


### PR DESCRIPTION
Fix the Python sdist/wheel build (common/*.h, per-dialect
tree_sitter/*.h, and cfml/queries/*.scm were missing, so pip install
from source failed and the HIGHLIGHTS_QUERY/INJECTIONS_QUERY/TAGS_QUERY
constants couldn't resolve), then wire cibuildwheel + build + trusted
publishing into release.yml so tagged releases publish to PyPI
alongside npm and crates.io.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018FzNLZyGfWFTiA5HmPzsiQ