### PR TITLE
Pin the common CFML constructs the corpus suite did not cover

### DIFF
--- a/cfml/test/corpus/common.txt
+++ b/cfml/test/corpus/common.txt
@@ -1,0 +1,320 @@
+================================================================================
+common: cfloop in its five forms
+================================================================================
+
+<cfloop index="i" from="1" to="10" step="2">#i#</cfloop>
+<cfloop collection="#data#" item="key">#key#</cfloop>
+<cfloop query="q" startrow="1" endrow="5">#q.id#</cfloop>
+<cfloop list="a,b,c" index="x" delimiters=",">#x#</cfloop>
+<cfloop condition="i LT 5"><cfset i++></cfloop>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (hash_single)
+    (html_text)
+    (hash_single)
+    (cf_end_tag
+      (cf_tag_name)))
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (hash_expression
+              (identifier)))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (hash_single)
+    (html_text)
+    (hash_single)
+    (cf_end_tag
+      (cf_tag_name)))
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (hash_single)
+    (html_text)
+    (hash_single)
+    (cf_end_tag
+      (cf_tag_name)))
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (hash_single)
+    (html_text)
+    (hash_single)
+    (cf_end_tag
+      (cf_tag_name)))
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_set_tag
+      (update_expression
+        (identifier))
+      (cf_selfclose_void_tag_end))
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: cfoutput with query and group
+================================================================================
+
+<cfoutput query="q" group="category">#category#<cfoutput>#q.name#</cfoutput></cfoutput>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_output_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (hash_expression
+      (identifier))
+    (cf_output_tag
+      (hash_expression
+        (member_expression
+          (identifier)
+          (property_identifier))))))
+
+================================================================================
+common: word operators in a cfif
+================================================================================
+
+<cfif a EQ b AND c NEQ d OR e CONTAINS "x" AND NOT f GTE g>ok</cfif>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_if_tag
+    (binary_expression
+      (binary_expression
+        (binary_expression
+          (identifier)
+          (identifier))
+        (binary_expression
+          (identifier)
+          (identifier)))
+      (binary_expression
+        (binary_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (binary_expression
+          (unary_expression
+            (unary_operator)
+            (identifier))
+          (identifier))))
+    (html_text)))
+
+================================================================================
+common: cfswitch with delimited cfcase and default
+================================================================================
+
+<cfswitch expression="#x#">
+<cfcase value="a,b" delimiters=",">A</cfcase>
+<cfdefaultcase>D</cfdefaultcase>
+</cfswitch>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (hash_expression
+              (identifier))))))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name)
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value)))))
+      (html_text)
+      (cf_end_tag
+        (cf_tag_name)))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name))
+      (html_text)
+      (cf_end_tag
+        (cf_tag_name)))
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: cflock and cfthread
+================================================================================
+
+<cflock name="l" timeout="10" type="exclusive"><cfset y = 2></cflock>
+<cfthread name="t" action="run"><cfset x = 1></cfthread>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_set_tag
+      (assignment_expression
+        (identifier)
+        (number))
+      (cf_selfclose_void_tag_end))
+    (cf_end_tag
+      (cf_tag_name)))
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_set_tag
+      (assignment_expression
+        (identifier)
+        (number))
+      (cf_selfclose_void_tag_end))
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: custom tags and taglib imports
+================================================================================
+
+<cfimport prefix="ui" taglib="/tags">
+<cf_mytag attr="1">body</cf_mytag>
+<ui:button label="Go" />
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_selfclose_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_selfclose_void_tag_end))
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (html_text)
+    (cf_end_tag
+      (cf_tag_name)))
+  (element
+    (self_closing_tag
+      (tag_name)
+      (tag_attributes
+        (attribute
+          (attribute_name)
+          (quoted_attribute_value
+            (attribute_value))))
+      (self_closing_tag_delimiter))))

--- a/cfquery/test/corpus/common.txt
+++ b/cfquery/test/corpus/common.txt
@@ -1,0 +1,142 @@
+===================================
+common: insert
+===================================
+INSERT INTO t (a, b) VALUES (1, 2)
+---
+
+(program
+  (query_keyword)
+  (query_keyword)
+  (query_identifier)
+  (parenthesized_query_node
+    (query_identifier)
+    (query_comma)
+    (query_identifier))
+  (query_keyword)
+  (parenthesized_query_node
+    (query_number
+      (number))
+    (query_comma)
+    (query_number
+      (number))))
+
+===================================
+common: update with where
+===================================
+UPDATE t SET a = 1, b = 'x' WHERE id = 3
+---
+
+(program
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_assignment_expression
+    (query_identifier)
+    (query_number
+      (number)))
+  (query_comma)
+  (query_assignment_expression
+    (query_identifier)
+    (quoted_query_value
+      (query_value)))
+  (query_keyword)
+  (query_assignment_expression
+    (query_identifier)
+    (query_number
+      (number))))
+
+===================================
+common: delete with where
+===================================
+DELETE FROM t WHERE id = 3
+---
+
+(program
+  (query_keyword)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_assignment_expression
+    (query_identifier)
+    (query_number
+      (number))))
+
+===================================
+common: subquery with exists and in
+===================================
+SELECT a FROM t
+WHERE EXISTS (SELECT 1 FROM u WHERE u.id = t.id)
+AND b IN (SELECT c FROM v)
+---
+
+(program
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_function
+    (query_function_name)
+    (parenthesized_query_node
+      (query_keyword)
+      (query_number
+        (number))
+      (query_keyword)
+      (query_identifier)
+      (query_keyword)
+      (query_alias
+        (query_identifier)
+        (query_assignment_expression
+          (query_identifier)
+          (query_alias
+            (query_identifier)
+            (query_identifier))))))
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (parenthesized_query_node
+    (query_keyword)
+    (query_identifier)
+    (query_keyword)
+    (query_identifier)))
+
+===================================
+common: left outer join with coalesce
+===================================
+SELECT COALESCE(a.name, b.name) AS n
+FROM a
+LEFT OUTER JOIN b ON a.id = b.id
+ORDER BY n
+---
+
+(program
+  (query_keyword)
+  (query_function
+    (query_function_name)
+    (parenthesized_query_node
+      (query_alias
+        (query_identifier)
+        (query_identifier))
+      (query_comma)
+      (query_alias
+        (query_identifier)
+        (query_identifier))))
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_keyword)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_alias
+    (query_identifier)
+    (query_assignment_expression
+      (query_identifier)
+      (query_alias
+        (query_identifier)
+        (query_identifier))))
+  (query_keyword)
+  (query_keyword)
+  (query_identifier))

--- a/cfscript/test/corpus/common.txt
+++ b/cfscript/test/corpus/common.txt
@@ -1,0 +1,387 @@
+================================================================================
+common: component attributes and properties
+================================================================================
+
+component extends="Base" implements="IFoo" accessors=true {
+
+	property name="id" type="numeric" default="0";
+	property string name;
+
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (component
+    (component_attribute
+      (identifier)
+      (string
+        (string_fragment)))
+    (component_attribute
+      (identifier)
+      (string
+        (string_fragment)))
+    (component_attribute
+      (identifier)
+      (true))
+    (component_body
+      (property_declaration
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment)))
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment)))
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment))))
+      (property_declaration
+        (identifier)
+        (identifier)))))
+
+================================================================================
+common: closures and arrow functions
+================================================================================
+
+f = ( x ) => x * 2;
+g = function( a, b ) { return a + b; };
+arr.each( function( item ) {
+	writeOutput( item );
+} );
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (arrow_function
+        (formal_parameters
+          (parameter_type
+            (identifier)))
+        (binary_expression
+          (identifier)
+          (number)))))
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (function_expression
+        (formal_parameters
+          (parameter_type
+            (identifier))
+          (parameter_type
+            (identifier)))
+        (statement_block
+          (return_statement
+            (binary_expression
+              (identifier)
+              (identifier)))))))
+  (expression_statement
+    (call_expression
+      (member_expression
+        (identifier)
+        (property_identifier))
+      (arguments
+        (function_expression
+          (formal_parameters
+            (parameter_type
+              (identifier)))
+          (statement_block
+            (expression_statement
+              (call_expression
+                (identifier)
+                (arguments
+                  (identifier))))))))))
+
+================================================================================
+common: chained member functions
+================================================================================
+
+result = list
+	.filter( function( x ) { return x.ok; } )
+	.map( function( x ) { return x.id; } )
+	.toList();
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (call_expression
+        (member_expression
+          (call_expression
+            (member_expression
+              (call_expression
+                (member_expression
+                  (identifier)
+                  (property_identifier))
+                (arguments
+                  (function_expression
+                    (formal_parameters
+                      (parameter_type
+                        (identifier)))
+                    (statement_block
+                      (return_statement
+                        (member_expression
+                          (identifier)
+                          (property_identifier)))))))
+              (property_identifier))
+            (arguments
+              (function_expression
+                (formal_parameters
+                  (parameter_type
+                    (identifier)))
+                (statement_block
+                  (return_statement
+                    (member_expression
+                      (identifier)
+                      (property_identifier)))))))
+          (property_identifier))
+        (arguments)))))
+
+================================================================================
+common: elvis and safe navigation
+================================================================================
+
+a = b ?: "default";
+c = obj?.prop?.method();
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (elvis_expression
+        (identifier)
+        (string
+          (string_fragment)))))
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (call_expression
+        (member_expression
+          (member_expression
+            (identifier)
+            (optional_chain)
+            (property_identifier))
+          (optional_chain)
+          (property_identifier))
+        (arguments)))))
+
+================================================================================
+common: queryExecute with params and options
+================================================================================
+
+q = queryExecute(
+	"SELECT id FROM t WHERE a = :a",
+	{ a: 1 },
+	{ datasource: "ds" }
+);
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (query_expression
+        (query_text)
+        (object
+          (pair
+            (property_identifier)
+            (number)))
+        (object
+          (pair
+            (property_identifier)
+            (string
+              (string_fragment))))))))
+
+================================================================================
+common: try catch finally
+================================================================================
+
+try {
+	risky();
+} catch ( any e ) {
+	log( e );
+} finally {
+	cleanup();
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (try_statement
+    (statement_block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (arguments))))
+    (catch_clause
+      (catch_type)
+      (identifier)
+      (statement_block
+        (expression_statement
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier))))))
+    (finally_clause
+      (statement_block
+        (expression_statement
+          (call_expression
+            (identifier)
+            (arguments)))))))
+
+================================================================================
+common: interface declaration
+================================================================================
+
+interface {
+
+	public string function getName();
+
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (component
+    (component_body
+      (function_declaration
+        (access_type)
+        (identifier)
+        (identifier)
+        (formal_parameters)))))
+
+================================================================================
+common: application lifecycle component
+================================================================================
+
+component {
+
+	this.name               = "app";
+	this.sessionManagement  = true;
+
+	function onRequestStart( required string target ) {
+		return true;
+	}
+
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (component
+    (component_body
+      (expression_statement
+        (assignment_expression
+          (member_expression
+            (this)
+            (property_identifier))
+          (string
+            (string_fragment))))
+      (expression_statement
+        (assignment_expression
+          (member_expression
+            (this)
+            (property_identifier))
+          (true)))
+      (function_declaration
+        (identifier)
+        (formal_parameters
+          (parameter_type)
+          (identifier))
+        (statement_block
+          (return_statement
+            (true)))))))
+
+================================================================================
+common: compound assignment and update operators
+================================================================================
+
+x += 1;
+y -= 2;
+z *= 3;
+w /= 4;
+s &= "a";
+i++;
+--j;
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (augmented_assignment_expression
+      (identifier)
+      (number)))
+  (expression_statement
+    (augmented_assignment_expression
+      (identifier)
+      (number)))
+  (expression_statement
+    (augmented_assignment_expression
+      (identifier)
+      (number)))
+  (expression_statement
+    (augmented_assignment_expression
+      (identifier)
+      (number)))
+  (expression_statement
+    (augmented_assignment_expression
+      (identifier)
+      (string
+        (string_fragment))))
+  (expression_statement
+    (update_expression
+      (identifier)))
+  (expression_statement
+    (update_expression
+      (identifier))))
+
+================================================================================
+common: nested struct and array literals
+================================================================================
+
+cfg = {
+	list: [ 1, 2, { a: "b" } ],
+	"quoted key": true,
+	nested: { deep: [ { x: 1 } ] }
+};
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (object
+        (pair
+          (property_identifier)
+          (array
+            (number)
+            (number)
+            (object
+              (pair
+                (property_identifier)
+                (string
+                  (string_fragment))))))
+        (pair
+          (string
+            (string_fragment))
+          (true))
+        (pair
+          (property_identifier)
+          (object
+            (pair
+              (property_identifier)
+              (array
+                (object
+                  (pair
+                    (property_identifier)
+                    (number)))))))))))


### PR DESCRIPTION
## Why

The existing corpus tests skew heavily toward keyword casing and CF tag edge cases. Ordinary CFML that works today — closures, `property`, `queryExecute`, `<cfloop>` in its various forms, `INSERT`/`UPDATE`/`DELETE` — was almost entirely unguarded.

**All 21 constructs added here already parse.** That is the point: nothing stops a future grammar change from silently breaking them. That is not hypothetical — three constructs regressed exactly that way last week (string slicing, a function named `instanceOf`, a `Component`-typed parameter), and they were only caught because something happened to pin them.

## What was added, and why these

Chosen by how often each appears across the 12,549-file real-world corpus, not by taste:

**cfscript** (10 tests)
| Construct | Files |
|---|---|
| component attributes + `property` | 1,986 |
| closures and arrow functions | 900 |
| Application.cfc lifecycle (`this.name`, `onRequestStart`) | 410 |
| `queryExecute` with params and options struct | 223 |
| `interface` declarations | 220 |
| chained member functions, elvis / safe navigation, try/catch/finally, compound assignment, nested struct+array literals | — |

**cfml** (6 tests) — `<cfloop>` in all five forms (index/collection/query/list/condition), `<cfoutput query group>` with a nested `<cfoutput>` (69), word operators (`EQ`/`NEQ`/`CONTAINS`/`NOT`/`GTE`), `<cfswitch>` with a delimited `<cfcase>`, `<cflock>` and `<cfthread>` (59/13), custom tags and `<cfimport taglib>` (184).

**cfquery** (5 tests) — `INSERT`, `UPDATE`, `DELETE`, `EXISTS`/`IN` subqueries, and `LEFT OUTER JOIN` with `COALESCE`. The existing cfquery tests were almost entirely `SELECT`.

## Verification

- Expectations generated, then grepped for `ERROR` / `MISSING` — none.
- **Confirmed the tests actually assert**: corrupting one expected node name (`arrow_function` → `WRONG_NODE`) makes the run fail with `✗ common: closures and arrow functions`, and reverting restores green. Worth checking explicitly, since `--update` accepts anything the parser produces.
- `npm test` — 250/250 (81 cfml, 104 cfscript, 65 cfquery), 0 failed parses
- `npm run probe` — no drift · `npm run lint` — clean

## Cost worth knowing about

A corpus test pins *tree shape*, not just "it parses". These 21 expectations will need regenerating whenever node names change — that is the price of the guard, and it is what makes the guard useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015LvkA2w88uREGwh77q3ffN)_