### PR TITLE
More corpus coverage, and stop `&lt;cftimer&gt;` being a void tag

### DIFF
--- a/cfml/test/corpus/common.txt
+++ b/cfml/test/corpus/common.txt
@@ -705,3 +705,658 @@ common: cfheader, cfcontent and cfcookie
       (quoted_cf_attribute_value
         (attribute_value)))
     (cf_selfclose_void_tag_end)))
+
+================================================================================
+common: cftimer with a body
+================================================================================
+
+<cfsilent><cfset x = 1></cfsilent>
+<cftimer label="t" type="inline"><cfset y = 2></cftimer>
+<cftrace text="here">
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name))
+    (cf_set_tag
+      (assignment_expression
+        (identifier)
+        (number))
+      (cf_selfclose_void_tag_end))
+    (cf_end_tag
+      (cf_tag_name)))
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_set_tag
+      (assignment_expression
+        (identifier)
+        (number))
+      (cf_selfclose_void_tag_end))
+    (cf_end_tag
+      (cf_tag_name)))
+  (cf_selfclose_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_selfclose_void_tag_end)))
+
+================================================================================
+common: cflogin, cfloginuser and cflogout
+================================================================================
+
+<cflogin><cfloginuser name="u" password="p" roles="admin,user"></cflogin><cflogout>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name)
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value)))))
+      (implicit_cf_end_tag))
+    (cf_end_tag
+      (cf_tag_name)))
+  (cf_selfclose_tag
+    (cf_selfclose_void_tag_end)))
+
+================================================================================
+common: cfdocument with sections and items
+================================================================================
+
+<cfdocument format="pdf"><cfdocumentsection><cfdocumentitem type="header">H</cfdocumentitem>body</cfdocumentsection></cfdocument>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name))
+      (cf_tag
+        (cf_start_tag
+          (cf_tag_name)
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value)))))
+        (html_text)
+        (cf_end_tag
+          (cf_tag_name)))
+      (html_text)
+      (cf_end_tag
+        (cf_tag_name)))
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: cfchart with series and data
+================================================================================
+
+<cfchart chartwidth="300"><cfchartseries type="bar" query="q" valuecolumn="v" itemcolumn="i"><cfchartdata item="a" value="1"></cfchartseries></cfchart>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name)
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value)))))
+      (cf_tag
+        (cf_start_tag
+          (cf_tag_name)
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value))))
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value)))))
+        (implicit_cf_end_tag))
+      (cf_end_tag
+        (cf_tag_name)))
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: cfform with inputs
+================================================================================
+
+<cfform action="x.cfm" method="post"><cfinput type="text" name="a" required="yes"><cfselect name="b" query="q" value="id" display="name"></cfselect><cftextarea name="c"></cftextarea></cfform>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name)
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value)))))
+      (cf_tag
+        (cf_start_tag
+          (cf_tag_name)
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value))))
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value))))
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value))))
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value)))))
+        (cf_end_tag
+          (cf_tag_name)))
+      (cf_tag
+        (cf_start_tag
+          (cf_tag_name)
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value)))))
+        (cf_end_tag
+          (cf_tag_name)))
+      (implicit_cf_end_tag))
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: cfspreadsheet, cfimage and cffeed
+================================================================================
+
+<cfspreadsheet action="write" filename="f.xls" query="q"><cfimage action="resize" source="a.png" width="10"><cffeed action="read" source="u" query="r">
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_selfclose_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_selfclose_void_tag_end))
+  (cf_selfclose_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_selfclose_void_tag_end))
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (implicit_cf_end_tag)))
+
+================================================================================
+common: cfldap, cfftp and cfpop
+================================================================================
+
+<cfldap server="s" action="query" name="r" attributes="cn"><cfftp connection="c" action="open" server="s"><cfpop action="getall" name="m" server="s">
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name)
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value)))))
+      (cf_tag
+        (cf_start_tag
+          (cf_tag_name)
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value))))
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value))))
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value)))))
+        (implicit_cf_end_tag))
+      (implicit_cf_end_tag))
+    (implicit_cf_end_tag)))
+
+================================================================================
+common: cfcollection, cfindex and cfsearch
+================================================================================
+
+<cfcollection action="create" collection="c" path="/p"><cfindex collection="c" action="refresh" type="path" key="k"><cfsearch collection="c" name="r" criteria="x">
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name)
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value)))))
+      (cf_tag
+        (cf_start_tag
+          (cf_tag_name)
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value))))
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value))))
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value)))))
+        (implicit_cf_end_tag))
+      (implicit_cf_end_tag))
+    (implicit_cf_end_tag)))
+
+================================================================================
+common: cfwddx, cfobjectcache and cfflush
+================================================================================
+
+<cfwddx action="cfml2wddx" input="#x#" output="y"><cfobjectcache action="clear"><cfflush interval="10">
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_selfclose_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (hash_expression
+          (identifier))))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_selfclose_void_tag_end))
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_selfclose_tag
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_selfclose_void_tag_end))
+    (implicit_cf_end_tag)))
+
+================================================================================
+common: cfassociate and cfexit in a custom tag
+================================================================================
+
+<cfif thisTag.executionMode EQ "start"><cfassociate basetag="cf_parent" datacollection="items"><cfexit method="exittemplate"></cfif>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_if_tag
+    (binary_expression
+      (member_expression
+        (identifier)
+        (property_identifier))
+      (string
+        (string_fragment)))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name)
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value)))))
+      (cf_selfclose_tag
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))
+        (cf_selfclose_void_tag_end))
+      (implicit_cf_end_tag))))
+
+================================================================================
+common: cfdbinfo and cfregistry
+================================================================================
+
+<cfdbinfo type="tables" name="t" datasource="ds"><cfregistry action="get" branch="b" entry="e" variable="v" type="string">
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name)
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value))))
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value)))))
+      (implicit_cf_end_tag))
+    (implicit_cf_end_tag)))
+
+================================================================================
+common: deeply nested tag chains
+================================================================================
+
+<cfoutput><cfif a><cfloop from="1" to="3" index="i"><cfif b><cfswitch expression="#i#"><cfcase value="1"><cfif c>#i#</cfif></cfcase></cfswitch></cfif></cfloop></cfif></cfoutput>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_output_tag
+    (cf_if_tag
+      (identifier)
+      (cf_tag
+        (cf_start_tag
+          (cf_tag_name)
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value))))
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value))))
+          (cf_tag_attributes
+            (cf_attribute
+              (cf_attribute_name)
+              (quoted_cf_attribute_value
+                (attribute_value)))))
+        (cf_if_tag
+          (identifier)
+          (cf_tag
+            (cf_start_tag
+              (cf_tag_name)
+              (cf_tag_attributes
+                (cf_attribute
+                  (cf_attribute_name)
+                  (quoted_cf_attribute_value
+                    (hash_expression
+                      (identifier))))))
+            (cf_tag
+              (cf_start_tag
+                (cf_tag_name)
+                (cf_tag_attributes
+                  (cf_attribute
+                    (cf_attribute_name)
+                    (quoted_cf_attribute_value
+                      (attribute_value)))))
+              (cf_if_tag
+                (identifier)
+                (hash_expression
+                  (identifier)))
+              (cf_end_tag
+                (cf_tag_name)))
+            (cf_end_tag
+              (cf_tag_name))))
+        (cf_end_tag
+          (cf_tag_name))))))

--- a/cfml/test/corpus/common.txt
+++ b/cfml/test/corpus/common.txt
@@ -318,3 +318,390 @@ common: custom tags and taglib imports
           (quoted_attribute_value
             (attribute_value))))
       (self_closing_tag_delimiter))))
+
+================================================================================
+common: cftry with typed cfcatch, cfrethrow and cffinally
+================================================================================
+
+<cftry><cfset x = 1><cfcatch type="database"><cfrethrow></cfcatch><cffinally><cfset y = 2></cffinally></cftry>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name))
+    (cf_set_tag
+      (assignment_expression
+        (identifier)
+        (number))
+      (cf_selfclose_void_tag_end))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name)
+        (cf_tag_attributes
+          (cf_attribute
+            (cf_attribute_name)
+            (quoted_cf_attribute_value
+              (attribute_value)))))
+      (cf_selfclose_tag
+        (cf_selfclose_void_tag_end))
+      (cf_end_tag
+        (cf_tag_name)))
+    (cf_tag
+      (cf_start_tag
+        (cf_tag_name))
+      (cf_set_tag
+        (assignment_expression
+          (identifier)
+          (number))
+        (cf_selfclose_void_tag_end))
+      (cf_end_tag
+        (cf_tag_name)))
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: cfinvoke with cfinvokeargument
+================================================================================
+
+<cfinvoke component="svc" method="run" returnvariable="r"><cfinvokeargument name="a" value="1"></cfinvoke>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_selfclose_tag
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_selfclose_void_tag_end))
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: cfhttp with cfhttpparam
+================================================================================
+
+<cfhttp url="https://x/y" method="post" result="res"><cfhttpparam type="formfield" name="a" value="1"></cfhttp>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_selfclose_tag
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_selfclose_void_tag_end))
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: cfmail with cfmailparam
+================================================================================
+
+<cfmail to="a@b.c" from="d@e.f" subject="s"><cfmailparam name="X" value="1">body</cfmail>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_selfclose_tag
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_selfclose_void_tag_end))
+    (html_text)
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: cfstoredproc with procparam and procresult
+================================================================================
+
+<cfstoredproc procedure="sp_x" datasource="ds"><cfprocparam type="in" cfsqltype="cf_sql_integer" value="1"><cfprocresult name="r"></cfstoredproc>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_selfclose_tag
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_selfclose_void_tag_end))
+    (cf_selfclose_tag
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_selfclose_void_tag_end))
+    (cf_end_tag
+      (cf_tag_name))))
+
+================================================================================
+common: cfargument, cfparam and cfreturn in a tag component
+================================================================================
+
+<cfcomponent><cffunction name="f"><cfargument name="a" type="string" required="true" default=""><cfparam name="url.id" type="numeric" default="0"><cfreturn arguments.a & "!"></cffunction></cfcomponent>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_component_open_tag
+    (cf_selfclose_void_tag_end))
+  (cf_function_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_selfclose_tag
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value))
+      (cf_selfclose_void_tag_end))
+    (cf_selfclose_tag
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_selfclose_void_tag_end))
+    (cf_return_tag
+      (binary_expression
+        (member_expression
+          (identifier)
+          (property_identifier))
+        (string
+          (string_fragment)))
+      (cf_selfclose_void_tag_end)))
+  (cf_component_close_tag))
+
+================================================================================
+common: query of queries with result and maxrows
+================================================================================
+
+<cfquery name="sub" dbtype="query" result="meta" maxrows="10">SELECT id FROM q WHERE id > 1</cfquery>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_query_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_query_content)))
+
+================================================================================
+common: cfqueryparam with a list
+================================================================================
+
+<cfquery name="q">SELECT * FROM t WHERE id IN (<cfqueryparam value="#ids#" list="yes" cfsqltype="cf_sql_integer">)</cfquery>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_query_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_query_content)))
+
+================================================================================
+common: cfmodule, cfinclude and cfabort
+================================================================================
+
+<cfmodule template="/t.cfm" attr="1"><cfinclude template="header.cfm"><cfif x><cfabort></cfif>
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_tag
+    (cf_start_tag
+      (cf_tag_name)
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value))))
+      (cf_tag_attributes
+        (cf_attribute
+          (cf_attribute_name)
+          (quoted_cf_attribute_value
+            (attribute_value)))))
+    (cf_selfclose_tag
+      (cf_attribute
+        (cf_attribute_name)
+        (quoted_cf_attribute_value
+          (attribute_value)))
+      (cf_selfclose_void_tag_end))
+    (cf_if_tag
+      (identifier)
+      (cf_selfclose_tag
+        (cf_selfclose_void_tag_end)))
+    (implicit_cf_end_tag)))
+
+================================================================================
+common: cfheader, cfcontent and cfcookie
+================================================================================
+
+<cfheader name="X" value="1"><cfcontent type="application/json"><cfcookie name="c" value="v" expires="never">
+
+--------------------------------------------------------------------------------
+
+(program
+  (cf_selfclose_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_selfclose_void_tag_end))
+  (cf_selfclose_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_selfclose_void_tag_end))
+  (cf_selfclose_tag
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_attribute
+      (cf_attribute_name)
+      (quoted_cf_attribute_value
+        (attribute_value)))
+    (cf_selfclose_void_tag_end)))

--- a/cfquery/test/corpus/common.txt
+++ b/cfquery/test/corpus/common.txt
@@ -140,3 +140,107 @@ ORDER BY n
   (query_keyword)
   (query_keyword)
   (query_identifier))
+
+===================================
+common: line and block comments with escaped quotes
+===================================
+SELECT 'it''s' AS s -- trailing
+FROM t /* block */ WHERE a = 1
+---
+
+(program
+  (query_keyword)
+  (quoted_query_value
+    (query_value))
+  (quoted_query_value
+    (query_value))
+  (query_keyword)
+  (query_identifier)
+  (comment)
+  (query_keyword)
+  (query_identifier)
+  (comment)
+  (query_keyword)
+  (query_assignment_expression
+    (query_identifier)
+    (query_number
+      (number))))
+
+===================================
+common: top with multi-column order by
+===================================
+SELECT TOP 10 a FROM t ORDER BY a DESC, b ASC
+---
+
+(program
+  (query_keyword)
+  (query_keyword)
+  (query_number
+    (number))
+  (query_identifier)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_comma)
+  (query_identifier)
+  (query_keyword))
+
+===================================
+common: cast, isnull and dateadd
+===================================
+SELECT CAST(a AS varchar(10)), ISNULL(b, 0), DATEADD(day, 1, c) FROM t
+---
+
+(program
+  (query_keyword)
+  (query_function
+    (query_function_name)
+    (parenthesized_query_node
+      (query_identifier)
+      (query_keyword)
+      (query_function
+        (query_function_name)
+        (parenthesized_query_node
+          (query_number
+            (number))))))
+  (query_comma)
+  (query_function
+    (query_function_name)
+    (parenthesized_query_node
+      (query_identifier)
+      (query_comma)
+      (query_number
+        (number))))
+  (query_comma)
+  (query_function
+    (query_function_name)
+    (parenthesized_query_node
+      (query_function_name)
+      (query_comma)
+      (query_number
+        (number))
+      (query_comma)
+      (query_identifier)))
+  (query_keyword)
+  (query_identifier))
+
+===================================
+common: union all
+===================================
+SELECT a FROM t UNION ALL SELECT b FROM u
+---
+
+(program
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_keyword)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_identifier))

--- a/cfquery/test/corpus/common.txt
+++ b/cfquery/test/corpus/common.txt
@@ -244,3 +244,76 @@ SELECT a FROM t UNION ALL SELECT b FROM u
   (query_identifier)
   (query_keyword)
   (query_identifier))
+
+===================================
+common: insert select with case expression
+===================================
+INSERT INTO t (a, b) SELECT CASE WHEN x > 1 THEN 'hi' ELSE 'lo' END, y FROM u WHERE z IS NOT NULL
+---
+
+(program
+  (query_keyword)
+  (query_keyword)
+  (query_identifier)
+  (parenthesized_query_node
+    (query_identifier)
+    (query_comma)
+    (query_identifier))
+  (query_keyword)
+  (query_keyword)
+  (query_keyword)
+  (query_comparison_expression
+    (query_identifier)
+    (query_number
+      (number)))
+  (query_keyword)
+  (quoted_query_value
+    (query_value))
+  (query_keyword)
+  (quoted_query_value
+    (query_value))
+  (query_keyword)
+  (query_comma)
+  (query_identifier)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_keyword)
+  (query_identifier))
+
+===================================
+common: group by with having and ordered aggregate
+===================================
+SELECT a, COUNT(*) c FROM t GROUP BY a HAVING COUNT(*) > 1 ORDER BY c DESC
+---
+
+(program
+  (query_keyword)
+  (query_identifier)
+  (query_comma)
+  (query_function
+    (query_function_name)
+    (parenthesized_query_node
+      (query_star
+        (star))))
+  (query_identifier)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword)
+  (query_comparison_expression
+    (query_function
+      (query_function_name)
+      (parenthesized_query_node
+        (query_star
+          (star))))
+    (query_number
+      (number)))
+  (query_keyword)
+  (query_keyword)
+  (query_identifier)
+  (query_keyword))

--- a/cfscript/test/corpus/common.txt
+++ b/cfscript/test/corpus/common.txt
@@ -385,3 +385,484 @@ cfg = {
                   (pair
                     (property_identifier)
                     (number)))))))))))
+
+================================================================================
+common: script-syntax lock, transaction and thread
+================================================================================
+
+function f() {
+	lock name="l" timeout=10 type="exclusive" {
+		x = 1;
+	}
+	transaction {
+		save();
+	}
+	thread name="t" {
+		work();
+	}
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (function_declaration
+    (identifier)
+    (formal_parameters)
+    (statement_block
+      (tag_statement
+        (identifier)
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (assignment_expression
+          (identifier)
+          (number))
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (statement_block
+          (expression_statement
+            (assignment_expression
+              (identifier)
+              (number)))))
+      (tag_statement
+        (identifier)
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments)))))
+      (tag_statement
+        (identifier)
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments))))))))
+
+================================================================================
+common: script-syntax savecontent
+================================================================================
+
+function f() {
+	savecontent variable="s" {
+		writeOutput( "hi" );
+	}
+	return s;
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (function_declaration
+    (identifier)
+    (formal_parameters)
+    (statement_block
+      (tag_statement
+        (identifier)
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments
+                (string
+                  (string_fragment)))))))
+      (return_statement
+        (identifier)))))
+
+================================================================================
+common: script-syntax loop forms
+================================================================================
+
+function f() {
+	loop from=1 to=10 index="i" { echo( i ); }
+	loop array=data item="x" { echo( x ); }
+	loop query=q { echo( q.id ); }
+	loop list="a,b" index="v" { echo( v ); }
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (function_declaration
+    (identifier)
+    (formal_parameters)
+    (statement_block
+      (tag_statement
+        (identifier)
+        (assignment_expression
+          (identifier)
+          (number))
+        (assignment_expression
+          (identifier)
+          (number))
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments
+                (identifier))))))
+      (tag_statement
+        (identifier)
+        (assignment_expression
+          (identifier)
+          (identifier))
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments
+                (identifier))))))
+      (tag_statement
+        (identifier)
+        (assignment_expression
+          (identifier)
+          (identifier))
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments
+                (member_expression
+                  (identifier)
+                  (property_identifier)))))))
+      (tag_statement
+        (identifier)
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments
+                (identifier)))))))))
+
+================================================================================
+common: for, for-in, while and do-while
+================================================================================
+
+for ( var i = 1; i <= 10; i++ ) { x(); }
+for ( var k in data ) { y( k ); }
+while ( a ) { b(); }
+do { c(); } while ( d );
+
+--------------------------------------------------------------------------------
+
+(program
+  (for_statement
+    (variable_declaration
+      (variable_declarator
+        (identifier)
+        (number)))
+    (binary_expression
+      (identifier)
+      (number))
+    (update_expression
+      (identifier))
+    (statement_block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (arguments)))))
+  (for_in_statement
+    (identifier)
+    (identifier)
+    (statement_block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (arguments
+            (identifier))))))
+  (while_statement
+    (parenthesized_expression
+      (identifier))
+    (statement_block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (arguments)))))
+  (do_statement
+    (statement_block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (arguments))))
+    (parenthesized_expression
+      (identifier))))
+
+================================================================================
+common: named arguments and argumentCollection
+================================================================================
+
+f( a = 1, b = "x" );
+g( argumentCollection = args );
+h( "positional", named = true );
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (call_expression
+      (identifier)
+      (arguments
+        (assignment_expression
+          (identifier)
+          (number))
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment))))))
+  (expression_statement
+    (call_expression
+      (identifier)
+      (arguments
+        (assignment_expression
+          (identifier)
+          (identifier)))))
+  (expression_statement
+    (call_expression
+      (identifier)
+      (arguments
+        (string
+          (string_fragment))
+        (assignment_expression
+          (identifier)
+          (true))))))
+
+================================================================================
+common: new and createObject
+================================================================================
+
+a = new Foo();
+b = new path.to.Bar( 1, 2 );
+c = createObject( "component", "path.Baz" );
+d = createObject( "java", "java.lang.String" );
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (new_expression
+        (identifier)
+        (arguments))))
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (new_expression
+        (member_expression
+          (member_expression
+            (identifier)
+            (property_identifier))
+          (property_identifier))
+        (arguments
+          (number)
+          (number)))))
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (call_expression
+        (identifier)
+        (arguments
+          (string
+            (string_fragment))
+          (string
+            (string_fragment))))))
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (call_expression
+        (identifier)
+        (arguments
+          (string
+            (string_fragment))
+          (string
+            (string_fragment)))))))
+
+================================================================================
+common: throw with named arguments
+================================================================================
+
+try {
+	x();
+} catch ( any e ) {
+	throw( type = "Custom", message = "bad", detail = e.message );
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (try_statement
+    (statement_block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (arguments))))
+    (catch_clause
+      (catch_type)
+      (identifier)
+      (statement_block
+        (throw_statement
+          (arguments
+            (assignment_expression
+              (identifier)
+              (string
+                (string_fragment)))
+            (assignment_expression
+              (identifier)
+              (string
+                (string_fragment)))
+            (assignment_expression
+              (identifier)
+              (member_expression
+                (identifier)
+                (property_identifier)))))))))
+
+================================================================================
+common: import and include statements
+================================================================================
+
+import foo.Bar;
+include "header.cfm";
+
+--------------------------------------------------------------------------------
+
+(program
+  (import_statement
+    (import_path
+      (identifier)
+      (identifier)))
+  (include_statement
+    (string
+      (string_fragment))))
+
+================================================================================
+common: javadoc annotations before a function
+================================================================================
+
+/**
+ * @hint Does a thing
+ * @arg.hint The argument
+ */
+function doThing( required string arg ) {
+	return arg;
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (comment)
+  (function_declaration
+    (identifier)
+    (formal_parameters
+      (parameter_type)
+      (identifier))
+    (statement_block
+      (return_statement
+        (identifier)))))
+
+================================================================================
+common: hash interpolation inside strings
+================================================================================
+
+msg  = "Hello #user.name#, you have #count# items";
+path = "/a/#b#/c";
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (string
+        (string_fragment)
+        (hash_expression
+          (member_expression
+            (identifier)
+            (property_identifier)))
+        (string_fragment)
+        (hash_expression
+          (identifier))
+        (string_fragment))))
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (string
+        (string_fragment)
+        (hash_expression
+          (identifier))
+        (string_fragment)))))
+
+================================================================================
+common: nested ternary
+================================================================================
+
+x = a ? ( b ? 1 : 2 ) : 3;
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (ternary_expression
+        (identifier)
+        (parenthesized_expression
+          (ternary_expression
+            (identifier)
+            (number)
+            (number)))
+        (number)))))
+
+================================================================================
+common: abstract and final functions
+================================================================================
+
+component {
+
+	abstract function a();
+	final function b() { return 1; }
+
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (component
+    (component_body
+      (function_declaration
+        (access_type)
+        (identifier)
+        (formal_parameters))
+      (function_declaration
+        (access_type)
+        (identifier)
+        (formal_parameters)
+        (statement_block
+          (return_statement
+            (number)))))))

--- a/cfscript/test/corpus/common.txt
+++ b/cfscript/test/corpus/common.txt
@@ -866,3 +866,201 @@ component {
         (statement_block
           (return_statement
             (number)))))))
+
+================================================================================
+common: ORM property attributes
+================================================================================
+
+component persistent="true" table="users" {
+
+	property name="id" fieldtype="id" generator="native";
+	property name="posts" fieldtype="one-to-many" cfc="Post" fkcolumn="userId" inverse="true";
+
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (component
+    (component_attribute
+      (identifier)
+      (string
+        (string_fragment)))
+    (component_attribute
+      (identifier)
+      (string
+        (string_fragment)))
+    (component_body
+      (property_declaration
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment)))
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment)))
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment))))
+      (property_declaration
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment)))
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment)))
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment)))
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment)))
+        (component_attribute
+          (identifier)
+          (string
+            (string_fragment)))))))
+
+================================================================================
+common: remote function attributes
+================================================================================
+
+component {
+
+	remote struct function api( required string q ) returnformat="json" access="remote" {
+		return {};
+	}
+
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (component
+    (component_body
+      (function_declaration
+        (access_type)
+        (identifier)
+        (identifier)
+        (formal_parameters
+          (parameter_type)
+          (identifier))
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (assignment_expression
+          (identifier)
+          (string
+            (string_fragment)))
+        (statement_block
+          (return_statement
+            (object_pattern)))))))
+
+================================================================================
+common: component metadata attributes
+================================================================================
+
+component output="false" serializable="false" hint="A service" displayname="Svc" {
+
+	function f() {}
+
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (component
+    (component_attribute
+      (identifier)
+      (string
+        (string_fragment)))
+    (component_attribute
+      (identifier)
+      (string
+        (string_fragment)))
+    (component_attribute
+      (identifier)
+      (string
+        (string_fragment)))
+    (component_attribute
+      (identifier)
+      (string
+        (string_fragment)))
+    (component_body
+      (function_declaration
+        (identifier)
+        (formal_parameters)
+        (statement_block)))))
+
+================================================================================
+common: script-syntax cfdocument and cfhttp
+================================================================================
+
+function f() {
+	cfdocument( format="pdf" ) {
+		writeOutput( "hi" );
+	}
+	cfhttp( url="https://x", method="get", result="r" ) {
+		cfhttpparam( type="header", name="A", value="1" );
+	}
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (function_declaration
+    (identifier)
+    (formal_parameters)
+    (statement_block
+      (tag_statement
+        (identifier)
+        (arguments
+          (assignment_expression
+            (identifier)
+            (string
+              (string_fragment))))
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments
+                (string
+                  (string_fragment)))))))
+      (tag_statement
+        (identifier)
+        (arguments
+          (assignment_expression
+            (identifier)
+            (string
+              (string_fragment)))
+          (assignment_expression
+            (identifier)
+            (string
+              (string_fragment)))
+          (assignment_expression
+            (identifier)
+            (string
+              (string_fragment))))
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments
+                (assignment_expression
+                  (identifier)
+                  (string
+                    (string_fragment)))
+                (assignment_expression
+                  (identifier)
+                  (string
+                    (string_fragment)))
+                (assignment_expression
+                  (identifier)
+                  (string
+                    (string_fragment)))))))))))

--- a/common/tag.h
+++ b/common/tag.h
@@ -320,7 +320,7 @@ static inline Tag tag_new() {
 }
 
 static const char *CF_VOID_TAGS[] = {
-    "COMPONENT", "PARAM", "ARGUMENT", "PROPERTY", "RETHROW", "THROW", "SCHEDULE", "HTTPPARAM", "QUERYPARAM", "TIMER", "FLUSH", "LOGOUT", "ZIPELEMENT",
+    "COMPONENT", "PARAM", "ARGUMENT", "PROPERTY", "RETHROW", "THROW", "SCHEDULE", "HTTPPARAM", "QUERYPARAM", "FLUSH", "LOGOUT", "ZIPELEMENT",
     "BREAK", "CONTINUE", "ABORT", "EXIT", "INCLUDE", "LOCATION", "HEADER", "DUMP",
     "CONTENT", "COOKIE", "LOG", "FILE", "DIRECTORY", "WDDX",
     "AUTHENTICATE", "NTAUTHENTICATE", "REPORTPARAM",
@@ -331,7 +331,13 @@ static const char *CF_VOID_TAGS[] = {
     // `<cfsetting>` never has a body — `</cfsetting>` does not appear once in
     // the 12,549-file corpus — but it was treated as a paired tag, so one
     // `<cfsetting showdebugoutput="false">` swallowed the rest of the template.
-    "SETTING", NULL
+    "SETTING",
+    // `TIMER` is deliberately absent: `<cftimer>` times the code between its
+    // start and end tags, so listing it here made `<cftimer label="t">…
+    // </cftimer>` fail. The corpus is silent on this one — `<cftimer` appears
+    // in none of the 12,549 files — so the call rests on the tag's semantics
+    // rather than on usage.
+    NULL
 };
 
 static inline bool cf_tag_name_in(const String *name, const char **list) {

--- a/test/probes/cfml/cftimer_with_body.cfm
+++ b/test/probes/cfml/cftimer_with_body.cfm
@@ -1,0 +1,7 @@
+<!--- `<cftimer>` times the code between its start and end tags, so it is not a
+      void tag. It was listed as one, which made the paired form fail. No corpus
+      file uses `<cftimer>` at all, so this rests on the tag's semantics rather
+      than on usage evidence. --->
+<cftimer label="request" type="inline">
+	<cfset result = expensiveCall()>
+</cftimer>

--- a/test/probes/expected.json
+++ b/test/probes/expected.json
@@ -5,6 +5,7 @@
     "cfml/cfif_function_call.cfm": "pass",
     "cfml/cfquery_hash_params.cfm": "pass",
     "cfml/cfsetting_void.cfc": "pass",
+    "cfml/cftimer_with_body.cfm": "pass",
     "cfml/dynamic_close_tag.cfc": "pass",
     "cfml/gt_in_text.cfm": "fail",
     "cfml/hash_in_comment_in_script.cfm": "pass",


### PR DESCRIPTION
Follow-up to #36, which merged while these two commits were still being written — they were pushed to the branch after it closed, so they need their own PR.

## `3ebe92b` — a real bug in the void-tag table

```cfml
<cftimer label="request" type="inline">
	<cfset result = expensiveCall()>
</cftimer>
```

did not parse. `TIMER` was in `CF_VOID_TAGS`, but the tag exists to time the code *between* its start and end tags — the paired form is the point of it. Removed from the table, with a probe covering it.

The evidence here is weaker than the `<cfsetting>` change in #33, and worth stating plainly: **the corpus is silent.** `<cftimer` appears in none of the 12,549 files, so this rests on the tag's documented semantics rather than usage data. Neighbouring cases verified to still hold — `<cftimer label="t" />` parses, the bodyless-then-content form parses, `<cfsetting>` stays void — and the corpus scan is unchanged at 1,352 error nodes, as expected for a tag nobody uses.

## `aa680ae` + `3ebe92b` — 44 more tests

**cfscript** — script-syntax `lock` / `transaction` / `thread` / `savecontent` / `loop` (all four loop forms), `for` / for-in / `while` / do-while, named arguments and `argumentCollection`, `new` and `createObject`, `throw()` with named arguments, `import` and `include`, javadoc annotations, hash interpolation in strings, nested ternary, `abstract` and `final` functions, ORM `property` attributes, `remote` function attributes, component metadata attributes, script-syntax `cfdocument` and `cfhttp`.

**cfml** — `<cftry>` with typed `<cfcatch>` / `<cfrethrow>` / `<cffinally>`, `<cfinvoke>`, `<cfhttp>`, `<cfmail>`, `<cfstoredproc>`, `<cfargument>` / `<cfparam>` / `<cfreturn>`, query of queries with `result` and `maxrows`, `<cfqueryparam list="yes">`, `<cfmodule>` / `<cfinclude>` / `<cfabort>`, `<cfheader>` / `<cfcontent>` / `<cfcookie>`, `<cftimer>` / `<cfsilent>` / `<cftrace>`, `<cflogin>`, `<cfdocument>` with sections, `<cfchart>` with series, `<cfform>` with inputs, `<cfspreadsheet>` / `<cfimage>` / `<cffeed>`, `<cfldap>` / `<cfftp>` / `<cfpop>`, `<cfcollection>` / `<cfindex>` / `<cfsearch>`, `<cfwddx>` / `<cfobjectcache>` / `<cfflush>`, `<cfassociate>` / `<cfexit>`, `<cfdbinfo>` / `<cfregistry>`, deeply nested tag chains.

**cfquery** — SQL line and block comments with `''` escaping, `TOP` with multi-column `ORDER BY`, `CAST` / `ISNULL` / `DATEADD`, `UNION ALL`, `INSERT … SELECT` with a `CASE` expression, `GROUP BY` with `HAVING` and an ordered aggregate.

## Verification

- **294 corpus tests**, 0 failed parses (103 cfml, 120 cfscript, 71 cfquery) — up from 229 before this branch
- No `ERROR` or `MISSING` nodes in any generated tree
- Confirmed the tests assert, by corrupting an expected node name and watching `✗ common: cfhttp with cfhttpparam` fail, then reverting
- `npm run probe` — no drift · `npm run lint` — clean
- Corpus scan unchanged at 1,352 error nodes across 12,549 files

Across three passes, 69 constructs were probed: 68 already parsed, 1 was broken. The fuzz jobs should run on this PR, since it touches `common/tag.h`.

## Not committed, deliberately

CRLF line endings and a leading BOM both parse in cfml and cfscript. They are left out because a corpus `.txt` cannot carry either reliably through a Windows checkout — such a test would assert the checkout's line endings rather than the parser's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015LvkA2w88uREGwh77q3ffN)_