### PR TITLE
Close the CI gap in the probe harness, and write down what the corpus work taught

### DIFF
--- a/.claude/skills/parse-gap/SKILL.md
+++ b/.claude/skills/parse-gap/SKILL.md
@@ -92,7 +92,13 @@ by source-line shape when you want to see what is left.
 
 If the change touches either scanner, also run `npm run fuzz` — it applies
 random edits to every corpus test and re-parses, which is the only thing that
-exercises scanner state transitions systematically.
+exercises scanner state transitions systematically. CI runs it for grammar and
+scanner paths, but locally is where you want to find a hang.
+
+If someone asks whether the change costs performance, use `npm run bench`
+(baseline first, then compare) rather than timing `npm run scan`. Scan time
+moves with the error count, so a change that fixes parse errors reads as a huge
+speedup or slowdown that has nothing to do with the parser.
 
 ## 5. Land it
 

--- a/.claude/skills/parse-gap/SKILL.md
+++ b/.claude/skills/parse-gap/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: parse-gap
+description: Workflow for making CFML/CFScript/SQL syntax parse in the tree-sitter-cfml grammars when it currently produces an ERROR node, plus diagnosing a parser that hangs or crashes. Use this whenever the task involves a construct that does not parse, an ERROR or MISSING node, a corpus scan finding, a request to "support" some CFML syntax, a grammar conflict from `tree-sitter generate`, or an external scanner change in `common/scanner.h` or `cfscript/src/scanner.c`. Also use it when a parse looks wrong rather than failing outright — the same reproduce-then-verify loop applies. Worth loading even for a change that looks like a one-line addition to a `choice`, because the verification gate is what catches the damage such changes do elsewhere.
+---
+
+# Fixing a parse gap
+
+The hard part of this repo is not writing the rule. It is knowing what else the
+rule breaks. Every change in the last round that looked self-contained still
+needed a full corpus re-scan to confirm, and three of them were only saved by
+that scan. The workflow below is built around that fact.
+
+## 1. Reproduce it as small as you can
+
+Start from the smallest input that still fails, not the file it came from. A
+100-node ERROR usually means *one* bad construct near the top of a file that
+cost the parser its nesting — the other 99 nodes are cascade, and chasing them
+wastes the session.
+
+```bash
+node -e "
+const Parser=require('tree-sitter'), langs=require('.');
+const p=new Parser(); p.setLanguage(langs.cfscript);
+console.log(p.parse('param string url.id default=\"0\";').rootNode.toString());
+"
+```
+
+Swap `cfscript` for `cfml` or `cfquery`. For a `.cfm` file whose failure is
+inside `<cfscript>` or `<cfquery>`, parse the *inner* text with the inner
+grammar — the outer tree will often look clean because the body is an injection.
+
+Once it is small, save it under `test/probes/<grammar>/<name>.<ext>` with a
+comment naming the real-world source. `npm run probe` then tracks it forever and
+tells you the moment it starts passing.
+
+## 2. Work out who owns it
+
+| The construct appears in | Edit |
+|---|---|
+| Tags, HTML, template text | `common/define-grammar.js` (affects `cfml` **and** `cfquery`) |
+| SQL inside `<cfquery>` | `common/define-grammar.js`, the `dialect === 'cfquery'` branch |
+| CFScript in a `.cfs` file | `cfscript/grammar.js` |
+| CFScript inside `<cfscript>` | `common/define-grammar.js` — a *different* copy of the same rules |
+
+The last row is the trap: CFScript exists twice. A construct that should work in
+both `.cfs` and `<cfscript>` needs the same change in both files, and they have
+drifted, so check rather than assume.
+
+If the construct's boundary is decided by scanning characters rather than by
+grammar rules — tag open/close matching, raw text, `#hash#` spans, implicit end
+tags — it is scanner work. Read `references/scanner.md` before touching either
+scanner; they have no generator to check your work.
+
+## 3. Make the change, expecting the lexer to fight you
+
+`word: $.identifier` means keyword extraction is **lexical**. A rule that makes
+a keyword valid in a new position changes how that word lexes in that whole
+parse state, including in rules you did not touch and tests you did not read.
+
+`references/hazards.md` catalogues the specific traps, each with the change that
+triggered it. Read it before editing declarations, parameters, statement heads,
+anything involving `:`, or the type slot of a rule. It will save you a cycle.
+
+The short version, because it comes up most: **prefer a plain `$.identifier`
+over a set of `keyword()` tokens** when a rule needs a word in a slot. Let what
+*follows* disambiguate. Spelling a type slot as `keyword('Array')` et al. is
+what broke `loop array=data item="x"`.
+
+## 4. Run the gate
+
+Every step, in order, on the *whole* project — not the dialect you edited:
+
+```bash
+npm run build          # full build; DIALECT=… skips the native addon rebuild
+npm test               # corpus tests, all three grammars
+npm run probe          # drift in either direction is a signal
+npm run lint
+```
+
+Then the part CI does not do, and the part that actually catches things:
+
+```bash
+npm run corpus:fetch                 # first time only; clones into /corpus
+npm run scan corpus > after.txt
+diff <(sort before.txt) <(sort after.txt)
+```
+
+Take `before.txt` *before* you edit. **A clean fix produces a diff of deletions
+only.** Any added line is a regression: back the change out and find a narrower
+formulation. `npm run corpus:report -- --from after.txt` clusters what remains
+by source-line shape when you want to see what is left.
+
+If the change touches either scanner, also run `npm run fuzz` — it applies
+random edits to every corpus test and re-parses, which is the only thing that
+exercises scanner state transitions systematically.
+
+## 5. Land it
+
+- **Corpus test** for the newly-supported construct. Write the input with a
+  `(program)` placeholder, run `npm run test:update`, then check `git diff` to
+  confirm only your block changed — `--update` rewrites expectations wholesale
+  and can never fail, so it is not a check, it is a code generator.
+- **`npm run probe -- --update`** to record probes that flipped to passing.
+- **Docs**: `LIMITATIONS.md` lists what does not parse — prune it as well as add
+  to it, it goes stale silently. `docs/FAILING-PATTERNS.md` carries the cost and
+  risk table; when an estimate there turns out wrong, say so and say why. That
+  record is the only calibration the next person gets.
+- **`CHANGELOG.md`** under `## [Unreleased]`, grouped by grammar.
+- **Commit message**: say what the corpus numbers did, and name anything that
+  broke on the way. A fix that needed two attempts is more useful written down
+  than a fix that looks like it worked first time.
+
+## Reference files
+
+- `references/hazards.md` — the traps, each with the change that triggered it.
+  Read before editing grammar rules.
+- `references/scanner.md` — how the external scanners work, what they cannot do,
+  and how to diagnose a hang or crash. Read before editing either scanner, or
+  when the parser stops responding.

--- a/.claude/skills/parse-gap/references/hazards.md
+++ b/.claude/skills/parse-gap/references/hazards.md
@@ -1,0 +1,134 @@
+# Hazards
+
+Each entry is a way this grammar has actually broken, not a general caution. The
+change that triggered it is named so you can judge whether your edit is the same
+shape.
+
+## Contents
+
+- [Keyword extraction is lexical](#keyword-extraction-is-lexical)
+- [`:` is contested by four rules](#-is-contested-by-four-rules)
+- [CFScript exists twice](#cfscript-exists-twice)
+- [`extras` match inside string literals](#extras-match-inside-string-literals)
+- [A widened rule swallows its neighbours](#a-widened-rule-swallows-its-neighbours)
+- [Single-rule conflicts cannot be declared](#single-rule-conflicts-cannot-be-declared)
+- [`--update` is a code generator, not a test](#--update-is-a-code-generator-not-a-test)
+- [Single-dialect builds leave the bindings stale](#single-dialect-builds-leave-the-bindings-stale)
+
+## Keyword extraction is lexical
+
+This is the one that keeps happening. With `word: $.identifier`, tree-sitter
+extracts keyword tokens: when the lexer reads a word, it checks whether a
+keyword token matching it is valid *in the current parse state*. If one is, that
+is what the word becomes. So making a keyword valid in a new position silently
+changes how that word lexes everywhere in that state — including in rules you
+did not edit.
+
+**Adding `member_expression` to `variable_declarator`** (to support
+`var local.x = 1`) made keyword-led expressions valid after `var`. That broke
+`var new = 1` and `for ( var export in … )`, because `new` and `export` now
+lexed as keywords where they used to be identifiers. Fixed by naming
+`_reserved_identifier` explicitly in the declarator and the for-header, so the
+identifier reading stays available.
+
+**Spelling a type slot as `keyword('Any')`, `keyword('Array')`, …** for the
+typed `param` statement made those words lex as keywords wherever the branch was
+live. `loop array=data item="x"` lost its `array` identifier and became an
+ERROR. Fixed by using a plain `$.identifier` for the type and letting what
+follows disambiguate — a name means the typed form, an `=` means the attribute
+form.
+
+The general move: **when a rule needs a word in a slot, reach for
+`$.identifier` before reaching for `keyword()`**. A closed set of keyword tokens
+feels more precise and is usually more dangerous. If you genuinely need keyword
+tokens, expect to add `_reserved_identifier` alternatives alongside them.
+
+Symptom to watch for: a corpus test failing on a construct that has nothing to
+do with your change, where the diff shows an identifier becoming an ERROR.
+
+## `:` is contested by four rules
+
+`pair`, `switch_case`, `slice_expression` and the ternary all want `:`. `pair`
+is reachable from `arguments` and `array`, which is why `case <expr> :` is
+ambiguous with the start of a pair — see the `[$.switch_case, $.expression]`
+conflict and its comment.
+
+The casing work removed conflicts around `:` deliberately. Adding a new `:`
+reading (a callback syntax, a type annotation, a label) tends to reintroduce the
+`case <expr> :` ambiguity, and the fix is not local. Budget accordingly, and
+treat "just one more `:` form" as a medium-risk change however small the diff.
+
+## CFScript exists twice
+
+`cfscript/grammar.js` is a standalone 1,500-line grammar. The CFScript rules
+inside `common/define-grammar.js` are a separate copy serving `<cfscript>` in
+`.cfm`/`.cfc` files. They have drifted.
+
+So: check both before concluding a construct is unsupported, and change both
+when adding one that should work in either place. A probe under
+`test/probes/cfml/` and one under `test/probes/cfscript/` is the cheapest way to
+keep yourself honest.
+
+## `extras` match inside string literals
+
+`extras` are matched *everywhere* the lexer runs, including inside string
+tokens. Adding CFML tag comments (`<!--- … --->`) as an extra made this line
+stop parsing:
+
+```cfml
+reReplace( src, "<!---.*?--->", "" )
+```
+
+The comment rule matched inside the string literal. Fixed by making `cf_comment`
+a `statement` instead of an extra — narrower, and it only appears where a
+statement can.
+
+If you are about to add something to `extras`, ask what happens when it appears
+inside a string, a regex, or a raw-text tag body.
+
+## A widened rule swallows its neighbours
+
+**Allowing member declarations after an access modifier** (`public prop = "x";`)
+also matched `public component function init()`, breaking nine corpus files —
+the declaration rule was happy to take `component` as the declared name. Fixed
+by restricting the member form to `_plain_declarator`, a bare identifier only.
+
+The pattern: when you widen a rule that starts with a common prefix, enumerate
+what *else* starts with that prefix. In this grammar that is usually access
+modifiers, `var`/`final`, and type names.
+
+## Single-rule conflicts cannot be declared
+
+`tree-sitter generate` sometimes suggests a conflict like `[$.expression]` — a
+single rule conflicting with itself. That cannot be declared; conflicts need two
+or more distinct rules. This is what blocked script-syntax tag calls
+(`cfdirectory( directory="#dir#" action="create" )`), where `f( a=1 [x] )` is
+ambiguous between a subscript and a second argument.
+
+When you hit this, the answer is not a conflict declaration but a narrower rule
+— for that case, a restricted attribute-value rule that cannot start with `[`.
+`prec.dynamic` is the other tool: it lets two readings both survive to the end
+of the parse and picks a winner, which works when the ambiguity resolves later.
+It does not help when the two readings diverge at the lexer.
+
+## `--update` is a code generator, not a test
+
+`tree-sitter test --update` (and `npm run test:update`) rewrites every
+expectation to whatever the parser currently produces. It can never fail. Run it
+to fill in a new test you just wrote, then read `git diff` and confirm only your
+block changed. If other blocks moved, you changed behaviour somewhere you did
+not intend to.
+
+`npm run probe` is the opposite and is the one to trust: it compares against a
+committed `expected.json` and fails on drift in *either* direction, so a gap
+closing is as visible as a regression.
+
+## Single-dialect builds leave the bindings stale
+
+`DIALECT=cfml npm run build` runs `tree-sitter generate` and stops. It does not
+rebuild the native addon. Anything going through the Node bindings —
+`npm run probe`, `npm run scan`, `npm run testbindings`, any `require('.')`
+one-liner — keeps using the previously compiled parser, and will happily report
+that your change did nothing, or that it worked when it did not.
+
+Run a full `npm run build` before believing any binding-based result.

--- a/.claude/skills/parse-gap/references/scanner.md
+++ b/.claude/skills/parse-gap/references/scanner.md
@@ -1,0 +1,126 @@
+# The external scanners
+
+Two of them, no generator, and the corpus scan is the only safety net. Read this
+before editing either, and when a parse hangs or crashes.
+
+## Contents
+
+- [Which scanner](#which-scanner)
+- [The rules of the lexer API](#the-rules-of-the-lexer-api)
+- [Infinite loops](#infinite-loops)
+- [Diagnosing a hang](#diagnosing-a-hang)
+- [Hunting for a bad input](#hunting-for-a-bad-input)
+
+## Which scanner
+
+- `common/scanner.h` — `cfml` and `cfquery`. Roughly 1,900 lines: tag name
+  matching against the tables in `common/tag.h`, implicit end tags, raw-text
+  bodies (`<script>`, `<style>`, `<cfsavecontent>`), `#hash#` spans, HTML text.
+  Dialect differences are `#ifdef`-gated. `cfml/src/scanner.c` and
+  `cfquery/src/scanner.c` are thin wrappers that `#include` it.
+- `cfscript/src/scanner.c` — `cfscript` only. Roughly 500 lines: automatic
+  semicolon insertion, template chars, the ternary `?` / elvis split, query
+  text, tag linefeeds, CFML comments in script bodies.
+
+They share nothing. A fix in one is not a fix in the other.
+
+## The rules of the lexer API
+
+`advance(lexer)` consumes a character into the token; `skip(lexer)` consumes it
+as leading whitespace/extra; `lexer->mark_end(lexer)` sets where the token ends.
+
+Three properties drive most scanner bugs:
+
+**You cannot rewind.** Once you have advanced past a character it is gone. If
+you peek at what follows a `<` and then return `false`, the dispatcher below you
+resumes *after* the `<` and never sees the tag or comment that started there.
+This broke every CFML comment in the corpus on the first attempt at treating a
+bare `<` as text. The fix was to only peek once some text had already been
+collected, which guarantees a `true` return, so the consumed character is always
+covered by a successful token. A `<` at the very start of a run falls through to
+the tag rules untouched.
+
+**`valid_symbols` tells you what the parser will accept here, and that is the
+only context you get.** Turning `>` into text is safe precisely when no closing
+delimiter is valid — `CLOSE_TAG_DELIM`, `CLOSE_CF_TAG_DELIM`,
+`SELF_CLOSING_TAG_DELIMITER`, `CF_SELF_CLOSING_TAG_DELIMITER`,
+`CF_SELF_CLOSING_VOID_TAG_DELIMITER`. Where none is expected, the parser is not
+inside a tag, so `>` cannot be closing one.
+
+**Zero-width tokens are legal but must not repeat.** ASI works by returning
+`true` having consumed nothing. That is fine as long as the resulting parse
+state no longer accepts the token; if it does, the parser loops forever emitting
+the same empty token.
+
+## Infinite loops
+
+`advance()` is a **no-op once `lexer->lookahead` is 0**. So any loop of the form
+
+```c
+while (lexer->lookahead != TERMINATOR) { ...; advance(lexer); }
+```
+
+spins forever on unterminated input. Every character-consuming loop needs
+`lexer->lookahead != 0` in its condition, or a `break` that fires at EOF.
+
+This is not hypothetical: `scan_query_text` in `cfscript/src/scanner.c` looped
+to the closing `"` with no EOF check, so `queryExecute("` hung the parser
+forever — including in an editor, mid-keystroke. It was adapted from a JSX
+scanner that *did* check; the check was dropped in the copy.
+
+Counter-bounded loops (`while (i < len)`) are fine as long as the counter
+advances unconditionally on every path.
+
+When you add or edit a loop, ask: what does this do on input that ends in the
+middle of the thing I am scanning? That is the state an editor is in on every
+keystroke.
+
+## Diagnosing a hang
+
+The Node wrapper is not where the work happens. `node_modules/tree-sitter-cli/cli.js`
+spawns a Rust binary; if you attach a debugger to the `node` process you will
+see it idle in `epoll_pwait` and learn nothing. Find the child:
+
+```bash
+# in one shell: start the hanging command in the background, note its pid
+# then:
+pgrep -P <node-pid>                       # the tree-sitter child
+gdb -p <child-pid> -batch -ex "bt 20"     # its stack
+```
+
+A stack ending in `tree_sitter_<lang>_external_scanner_scan` with 100% CPU is a
+scanner loop. The frame below it usually names the character it is stuck on —
+`__iswspace (wc=0)` means it is looping on EOF.
+
+For a hang under the Node bindings instead, remember the parse is synchronous:
+the process freezes, so you cannot catch it from inside. Run the parse in a
+child process that writes each candidate input to a file *before* parsing it,
+then read that file after the child times out. See the next section.
+
+## Hunting for a bad input
+
+`npm run fuzz` finds these, but only across a whole run and only sometimes — the
+mutation has to happen to produce the bad shape. If a fuzz run hangs
+intermittently, do not conclude the fuzzer is flaky on the strength of one clean
+retry. Run the same case twenty times; a 2-in-20 reproduction rate looks like
+zero at n=1.
+
+To minimise from a fuzzer hang to a one-liner: take the mutated input the
+fuzzer was on, then bisect it by hand against a small runner that parses one
+file with a timeout. Delete half, re-test, repeat. Going from a mutated
+four-line corpus test to `queryExecute("` took about ten iterations of that.
+
+To search for a bad input from scratch, mutate a seed with random
+inserts/deletes in a loop, writing each candidate to disk before parsing, and
+run the whole thing under `timeout`. Whatever is on disk when it dies is the
+culprit. Bias the inserted characters toward the ones the scanner branches on —
+`{ } ; " # < > ( ) = :` — rather than uniform ASCII.
+
+## Before you commit a scanner change
+
+- `npm run build` (full), `npm test`, `npm run probe`, `npm run lint`
+- `npm run fuzz` — mandatory for scanner changes; it is the only thing that
+  exercises state transitions systematically
+- Full corpus scan diffed against a pre-change baseline; deletions only
+- Spot-check truncated inputs by hand: `<cf`, `<!--- x`, `<cfoutput>#a`,
+  `<cfquery>SELECT 1`, `queryExecute("`, `x = {`. Each should recover, not hang.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm test
+      # The probes are minimal reductions of constructs found in real CFML, with
+      # their current pass/fail status committed in test/probes/expected.json.
+      # This fails on drift in either direction, so a gap closing is as loud as a
+      # regression — but only if it actually runs, which until now it did not.
+      - run: npm run probe
+      - run: npm run testbindings
       - run: npm run lint
 
   test_windows:
@@ -66,4 +72,5 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm test
+      - run: npm run probe
       - run: npm run lint

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,6 +10,13 @@ on:
       - "cfquery/src/scanner.c"
       - "common/scanner.h"
       - "common/tag.h"
+      # Grammar sources too, not just the scanners. Which external tokens are
+      # valid depends on the parse state, so a grammar change can put the
+      # scanner somewhere it has never been asked to scan before — and a
+      # zero-width token that repeats loops the parser with no scanner edit at
+      # all. The job costs ~30s per dialect; a hang costs 15 minutes.
+      - "common/define-grammar.js"
+      - "cfscript/grammar.js"
       # The fuzzer itself, so a change to it is validated by running it.
       - ".github/workflows/fuzz.yml"
       - "scripts/fuzz.js"
@@ -22,6 +29,13 @@ on:
       - "cfquery/src/scanner.c"
       - "common/scanner.h"
       - "common/tag.h"
+      # Grammar sources too, not just the scanners. Which external tokens are
+      # valid depends on the parse state, so a grammar change can put the
+      # scanner somewhere it has never been asked to scan before — and a
+      # zero-width token that repeats loops the parser with no scanner edit at
+      # all. The job costs ~30s per dialect; a hang costs 15 minutes.
+      - "common/define-grammar.js"
+      - "cfscript/grammar.js"
       # The fuzzer itself, so a change to it is validated by running it.
       - ".github/workflows/fuzz.yml"
       - "scripts/fuzz.js"

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ pnpm-debug.log*
 coverage/
 .nyc_output/
 
+# Per-developer Claude Code settings. `.claude/skills/` and any committed
+# `.claude/settings.json` are shared; this file is local permission grants.
+.claude/settings.local.json
+
 # OS / editor cruft
 .DS_Store
 Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,19 @@ npm run scan corpus > scan.txt          # or any directory of .cfm/.cfc/.cfs fil
 npm run corpus:report -- --from scan.txt  # group failures by source-line shape
 ```
 
+Check a grammar or scanner change for a throughput regression:
+
+```bash
+npm run bench -- corpus --out before.json   # on the base commit
+npm run bench -- corpus --baseline before.json   # after the change
+```
+
+Do not time `npm run scan` for this. It walks every tree collecting ERROR nodes
+and locates injections *by parsing*, so both costs move with the error count —
+a change that fixes parse errors will look wildly faster or slower for reasons
+unrelated to parser speed. `bench.js` selects its input by regex, reads it up
+front, and times only `parser.parse()`.
+
 Playground (browser):
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 npm install        # install deps, build native addon, download tree-sitter CLI binary
 npm run build      # regenerate parsers (tree-sitter generate) + rebuild native addon
 npm test           # run corpus tests for all three grammars
+npm run probe      # parse test/probes/* and fail on any drift from expected.json
+npm run fuzz       # tree-sitter's own fuzzer over the corpus tests
 npm run lint       # ESLint
 npm run lint:fix   # ESLint with auto-fix
 npm run testbindings  # Node binding smoke test
@@ -20,20 +22,27 @@ DIALECT=cfml npm run build
 DIALECT=cfml npm test
 ```
 
+`DIALECT=… npm run build` runs `tree-sitter generate` **without** rebuilding the
+native addon, so anything that goes through the Node bindings — `npm run probe`,
+`npm run scan`, `npm run testbindings` — keeps using the previous parser. Run a
+full `npm run build` before trusting those.
+
 Run tests / generate from inside a dialect directory:
 
 ```bash
 cd cfml
 node ../node_modules/tree-sitter-cli/cli.js test
-node ../node_modules/tree-sitter-cli/cli.js test --filter "cfif"   # run tests matching a name
+node ../node_modules/tree-sitter-cli/cli.js test -i "cfif"   # regex over test names (not --filter)
 node ../node_modules/tree-sitter-cli/cli.js generate
 node ../node_modules/tree-sitter-cli/cli.js parse path/to/file.cfc
 ```
 
-Scan a directory of CFML files for parse errors:
+Scan real-world CFML for parse errors, and cluster what comes back:
 
 ```bash
-npm run scan path/to/cfml/project
+npm run corpus:fetch                    # clone ~25 public CFML repos into /corpus (gitignored)
+npm run scan corpus > scan.txt          # or any directory of .cfm/.cfc/.cfs files
+npm run corpus:report -- --from scan.txt  # group failures by source-line shape
 ```
 
 Playground (browser):
@@ -51,27 +60,48 @@ npm run release -- 0.26.x   # bumps versions, builds, tests, commits, tags, push
 
 ## Architecture
 
-Three grammars share a single scanner and grammar base:
+Three grammars, but **not** three of a kind — `cfml` and `cfquery` share a
+grammar definition and a scanner; `cfscript` has its own of each. Knowing which
+you are editing is the difference between a one-line change and a change that
+lands in two grammars at once:
 
-| Directory  | Grammar   | File types       | Purpose                              |
-|------------|-----------|------------------|--------------------------------------|
-| `cfml/`    | `cfml`    | `.cfc`, `.cfm`   | Tags + embedded CFScript + HTML      |
-| `cfscript/`| `cfscript`| `.cfs`           | Pure CFScript                        |
-| `cfquery/` | `cfquery` | _(embedded)_     | SQL inside `<cfquery>` with `#hash#` |
+| Directory  | Grammar   | File types       | Grammar rules              | External scanner        |
+|------------|-----------|------------------|----------------------------|-------------------------|
+| `cfml/`    | `cfml`    | `.cfc`, `.cfm`   | `common/define-grammar.js` | `common/scanner.h`      |
+| `cfquery/` | `cfquery` | _(embedded)_     | `common/define-grammar.js` | `common/scanner.h`      |
+| `cfscript/`| `cfscript`| `.cfs`           | `cfscript/grammar.js`      | `cfscript/src/scanner.c` |
+
+`cfml` covers tags plus embedded CFScript and HTML; `cfquery` covers SQL inside
+`<cfquery>` with `#hash#` interpolation; `cfscript` is pure CFScript.
+
+A construct that exists in both CFScript-in-a-tag and standalone `.cfs` has to
+be added **twice** — once in `common/define-grammar.js`, once in
+`cfscript/grammar.js`. They have drifted; do not assume a rule present in one is
+present in the other.
 
 Each dialect directory has:
-- `grammar.js` — one-liner that calls `require('../common/define-grammar')('cfml'|'cfscript'|'cfquery')`
-- `src/` — **generated** C files (`parser.c`, `scanner.c`); committed, not hand-edited
+- `grammar.js` — for `cfml`/`cfquery`, a one-liner calling `require('../common/define-grammar')(dialect)`; for `cfscript`, the whole grammar
+- `src/parser.c`, `src/grammar.json`, `src/node-types.json` — **generated** by `tree-sitter generate`; committed, never hand-edited
+- `src/scanner.c` — **hand-written**. For `cfml`/`cfquery` it is a thin wrapper that `#include`s `common/scanner.h`; for `cfscript` it is the real 500-line scanner
 - `queries/` — `.scm` query files (highlights, indents, injections, tags, etc.)
-- `test/corpus/` — plain-text corpus tests in the format: `===title===` / CFML input / `---` / expected S-expression
+- `test/corpus/` — plain-text corpus tests: `===title===` / CFML input / `---` / expected S-expression
 
 ### Shared code (`common/`)
 
-- `define-grammar.js` — the full grammar definition, parameterised by `dialect`. All grammar rules live here; the per-dialect `grammar.js` files are thin wrappers.
-- `scanner.h` — external C scanner (implicit end tags, CF tag name matching, `#hash#` expressions, raw text). Dialect-specific behaviour is `#ifdef`-gated on the `dialect` token.
-- `tag.h` — CF tag name tables used by the scanner.
+- `define-grammar.js` — the `cfml` + `cfquery` grammar, parameterised by `dialect`. Rules unique to one appear inside `dialect === 'cfquery' ? … : …` branches.
+- `scanner.h` — the `cfml` + `cfquery` external scanner (implicit end tags, CF tag name matching, `#hash#` expressions, raw text). Dialect-specific behaviour is `#ifdef`-gated.
+- `tag.h` — CF tag name tables used by the scanner (void tags, raw-text tags).
 
-Changes to `define-grammar.js` or `scanner.h` affect all three grammars; always run `npm run build` and `npm test` after editing either.
+Editing either file changes two grammars at once, so run a full `npm run build`
+and `npm test` afterwards, never a single-dialect build.
+
+### Tests, probes and the corpus
+
+Three layers, each catching what the one above misses:
+
+- `cf*/test/corpus/` — the committed expectations. `npm test` runs them.
+- `test/probes/` — minimal reductions of constructs found in real code, with their current pass/fail status in `test/probes/expected.json`. `npm run probe` fails on drift **in either direction**, so a gap closing is as visible as a regression.
+- the real-world corpus (`npm run corpus:fetch`) — 12,500 files from public CFML projects. Not in CI; run it by hand before and after a grammar change and diff the two scans. Three changes in the last round looked self-contained, passed the test suite, and were only caught here.
 
 ### Bindings (`bindings/`)
 
@@ -83,9 +113,19 @@ Beyond the standard `highlights.scm`, `indents.scm`, `injections.scm`, `tags.scm
 
 ## Key constraints
 
-- **Grammar conflicts:** `tree-sitter generate` may warn about "unnecessary conflicts" from `define-grammar.js`. Ignore them if `npm run build` and `npm test` succeed.
+- **Grammar conflicts:** `tree-sitter generate` warns about "unnecessary conflicts" when a declared conflict is no longer reachable. Prune them rather than living with them — a stale declaration hides a real ambiguity behind a warning nobody reads. Removing one is safe exactly when `npm run build`, `npm test` and `npm run probe` all stay green.
+- **Keyword extraction is lexical.** With `word: $.identifier`, making a keyword token valid in a new position changes how that word *lexes* in that state — including in rules you did not touch. This is the single most common way a change here breaks something unrelated. See the skill below before editing declarations, parameters or statement heads.
 - **Generated files are committed** — `cf*/src/` must be up to date at release time; interim work does not need them regenerated.
 - **CFML engine target:** Use [Lucee](https://lucee.org/) as the reference runtime. Avoid Adobe-only or Lucee-only constructs; prefer portable CFML.
 - **Node version:** `>=18 <=24` (`.nvmrc` in repo root).
 - **`tree-sitter` CLI:** Scripts use the locally installed binary (`node_modules/tree-sitter-cli/`); a global install is not required.
-- **Known parser limitations** are documented in [`LIMITATIONS.md`](LIMITATIONS.md) — check there before investigating a surprising parse result.
+- **Known parser limitations** are documented in [`LIMITATIONS.md`](LIMITATIONS.md) — check there before investigating a surprising parse result. [`docs/FAILING-PATTERNS.md`](docs/FAILING-PATTERNS.md) has the longer version: every construct in the real-world corpus that still fails, how many files it affects, and an estimate of what fixing it would cost, calibrated against changes that have actually landed here.
+
+## Skills
+
+`.claude/skills/parse-gap/` covers the workflow for making a CFML construct
+parse that currently does not: reproducing it, deciding which grammar and
+scanner own it, the hazards specific to this repo, and the verification gate to
+run before committing. Its `references/scanner.md` also covers diagnosing a
+parser that hangs or crashes. Reach for it whenever the task is "this CFML
+doesn't parse" or "the parser hangs on X".

--- a/CORPUS.md
+++ b/CORPUS.md
@@ -11,6 +11,7 @@ npm run corpus:fetch     # shallow-clone the curated repo list into ./corpus (~1
 npm run scan corpus      # one line per ERROR / MISSING node
 npm run corpus:report    # the same scan, clustered into distinct failure sites
 npm run probe            # minimal reductions of every construct found below
+npm run bench -- corpus  # parser throughput; add --out/--baseline to compare builds
 ```
 
 `corpus/` is gitignored — it is third-party code under a mix of licences and is
@@ -126,8 +127,10 @@ identifier names so `public component function init()` stayed a function.
 ### Performance
 
 Measured over the corpus with each grammar fed byte-identical inputs (whole
-files for `cfml`, extracted script regions for `cfscript`, query regions for
-`cfquery`), best of three repetitions, two samples per build:
+files for `cfml`, script components and `<cfscript>` regions for `cfscript`,
+query regions for `cfquery`), best of three repetitions, two samples per build.
+`npm run bench` is that measurement, committed so the numbers below can be
+reproduced and so the next comparison uses the same method:
 
 | | `master` | casing branch | this branch |
 |---|---|---|---|
@@ -138,6 +141,14 @@ files for `cfml`, extracted script regions for `cfscript`, query regions for
 Run-to-run spread on one build is 3–7% (20% for the much smaller `cfquery`
 input), so **no parse-time regression is measurable** — the differences are
 inside the noise.
+
+Timing `npm run scan` instead is the trap here, and it produced a confident
+"+65% regression" that did not exist: `scan.js` walks every tree collecting
+ERROR nodes and finds injected regions *by parsing them*, so both costs move
+with the error count. A change that fixes parse errors therefore reads as a
+large speed change for reasons unrelated to the parser. `bench.js` selects
+input by regex, reads it before the clock starts, and times only
+`parser.parse()`.
 
 What does grow is the generated tables: `parser.c` totals 34.5 MB on `master`
 against 41.5 MB here (+20%), and the compiled Node addon 7.14 MB against

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "parse": "node scripts/parse.js",
     "scan": "node scripts/scan.js",
     "probe": "node scripts/probe.js",
+    "bench": "node scripts/bench.js",
     "fuzz": "node scripts/fuzz.js",
     "corpus:fetch": "node scripts/fetch-corpus.js",
     "corpus:report": "node scripts/corpus-report.js",

--- a/scripts/bench.js
+++ b/scripts/bench.js
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/**
+ * Parser throughput benchmark.
+ *
+ *   npm run bench -- corpus --out before.json
+ *   # ...change the grammar, npm run build...
+ *   npm run bench -- corpus --baseline before.json
+ *
+ * Answers one question: did a grammar or scanner change make parsing slower?
+ *
+ * Why this exists rather than timing `npm run scan`: `scan.js` walks every tree
+ * collecting ERROR nodes and re-parses injected regions that it locates *by
+ * parsing*. Both costs move when a grammar change moves the error count, so a
+ * change that fixes parse errors looks dramatically slower or faster for
+ * reasons that have nothing to do with parser speed. Measuring that way once
+ * produced a confident "+65% regression" that did not exist.
+ *
+ * What this does instead:
+ *
+ * - **Input selection never depends on the parser.** Injected `<cfscript>` and
+ *   `<cfquery>` bodies are found by regex, so the byte count fed to each
+ *   grammar is identical before and after a change.
+ * - **Files are read and sliced up front**, outside the timed region, so disk
+ *   and string work do not land in the measurement.
+ * - **Only `parser.parse()` is timed.** No tree walking, no node counting.
+ * - **Best of N reps, not the mean.** A benchmark on a shared runner competes
+ *   with other processes; that noise only ever makes a run slower, so the
+ *   fastest rep is the closest to the parser's real cost. The spread across
+ *   reps is reported so you can see whether the machine was quiet.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {join, relative} = path;
+
+const root = join(__dirname, '..');
+
+let Parser; let languages;
+try {
+  Parser = require('tree-sitter');
+  languages = require(root);
+} catch (e) {
+  console.error('bench: node bindings unavailable (run `npm install` first)');
+  console.error(`  ${e.message}`);
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const dir = args.find((a) => !a.startsWith('--'));
+const flag = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i === -1 ? fallback : args[i + 1];
+};
+
+if (!dir) {
+  console.error('Usage: npm run bench -- <dir> [--reps 5] [--out file.json] [--baseline file.json]');
+  console.error('  <dir>  a tree of .cfm/.cfc/.cfml/.cfs files, e.g. `corpus` after `npm run corpus:fetch`');
+  process.exit(1);
+}
+
+const reps = Number(flag('reps', 5));
+const outFile = flag('out', null);
+const baselineFile = flag('baseline', null);
+
+// Anything below this is machine noise, not a code change. Calibrated by
+// running the same commit against itself: repeated best-of-5 runs on an idle
+// machine land within about 2%.
+const NOISE_FLOOR_PCT = 3;
+
+const TEMPLATE_EXT = new Set(['.cfm', '.cfml', '.cfc']);
+const SCRIPT_EXT = new Set(['.cfs']);
+
+// Deliberately regex, not parse-driven: the whole point is that the workload
+// handed to each grammar must not shift when the grammar changes. These match
+// what the injection queries target closely enough for a throughput number, and
+// unlike the real injections they cost the same on every run.
+const SCRIPT_BLOCK = /<cfscript\b[^>]*>([\s\S]*?)<\/cfscript\s*>/gi;
+const QUERY_BLOCK = /<cfquery\b[^>]*>([\s\S]*?)<\/cfquery\s*>/gi;
+
+// A script-syntax `.cfc` (`component { … }`) is a cfscript file in all but
+// extension, and there are far more of those in real projects than there are
+// `<cfscript>` blocks. Missing them would leave the cfscript number measuring a
+// tenth of its real workload. Detected by stripping leading whitespace and
+// comments and looking at the first keyword — deterministic, and crucially not
+// dependent on whether the file parses.
+const LEADING_TRIVIA = /^(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\n]*|<!---[\s\S]*?--->)*/;
+const SCRIPT_COMPONENT_HEAD = /^(?:abstract|final|component|interface|import|private|public|package|remote|static)\b/i;
+
+/**
+ * Recursively collect parseable files under a directory.
+ *
+ * @param {string} start
+ * @returns {Array<string>}
+ */
+function collect(start) {
+  const out = [];
+  const walk = (d) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(d, {withFileTypes: true});
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(d, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === '.git' || entry.name === 'node_modules') continue;
+        walk(full);
+      } else if (TEMPLATE_EXT.has(path.extname(entry.name).toLowerCase()) ||
+                 SCRIPT_EXT.has(path.extname(entry.name).toLowerCase())) {
+        out.push(full);
+      }
+    }
+  };
+  walk(start);
+  // Sorted so two runs feed the parsers in the same order — parse order can
+  // matter for allocator behaviour, and a stable order keeps runs comparable.
+  return out.sort();
+}
+
+/**
+ * Build the per-grammar input lists. Runs once, outside the timed region.
+ *
+ * @param {Array<string>} files
+ * @returns {{cfml: Array<string>, cfscript: Array<string>, cfquery: Array<string>}}
+ */
+function buildWorkload(files) {
+  const work = {cfml: [], cfscript: [], cfquery: []};
+  for (const file of files) {
+    let text;
+    try {
+      text = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    if (SCRIPT_EXT.has(path.extname(file).toLowerCase())) {
+      work.cfscript.push(text);
+      continue;
+    }
+    // Templates go to cfml whatever their syntax — that is what an editor opens
+    // them with, and the injection is cfml's job.
+    work.cfml.push(text);
+    if (SCRIPT_COMPONENT_HEAD.test(text.replace(LEADING_TRIVIA, ''))) {
+      work.cfscript.push(text);
+    }
+    for (const m of text.matchAll(SCRIPT_BLOCK)) {
+      if (m[1].trim()) work.cfscript.push(m[1]);
+    }
+    for (const m of text.matchAll(QUERY_BLOCK)) {
+      if (m[1].trim()) work.cfquery.push(m[1]);
+    }
+  }
+  return work;
+}
+
+/**
+ * Time one full pass over one grammar's inputs.
+ *
+ * @param {object} parser
+ * @param {Array<string>} inputs
+ * @returns {number} milliseconds
+ */
+function timePass(parser, inputs) {
+  const started = process.hrtime.bigint();
+  for (const text of inputs) {
+    parser.parse(text);
+  }
+  return Number(process.hrtime.bigint() - started) / 1e6;
+}
+
+console.log(`bench: collecting from ${dir}`);
+const files = collect(dir);
+if (files.length === 0) {
+  console.error(`bench: no .cfm/.cfml/.cfc/.cfs files under ${dir}`);
+  process.exit(1);
+}
+const work = buildWorkload(files);
+
+const parsers = {};
+for (const name of ['cfml', 'cfscript', 'cfquery']) {
+  parsers[name] = new Parser();
+  parsers[name].setLanguage(languages[name]);
+}
+
+const bytes = {};
+for (const name of Object.keys(work)) {
+  bytes[name] = work[name].reduce((n, s) => n + Buffer.byteLength(s), 0);
+}
+
+console.log(`bench: ${files.length} files -> ` +
+  Object.keys(work).map((n) => `${n} ${work[n].length} inputs / ${(bytes[n] / 1e6).toFixed(1)} MB`).join(', '));
+console.log(`bench: ${reps} timed reps after a warm-up (reporting the fastest)\n`);
+
+const result = {reps, files: files.length, grammars: {}};
+
+for (const name of ['cfml', 'cfscript', 'cfquery']) {
+  if (work[name].length === 0) continue;
+  timePass(parsers[name], work[name]); // warm-up: JIT, allocator, page cache
+  const times = [];
+  for (let i = 0; i < reps; i++) {
+    times.push(timePass(parsers[name], work[name]));
+  }
+  const best = Math.min(...times);
+  const worst = Math.max(...times);
+  result.grammars[name] = {
+    ms: Number(best.toFixed(1)),
+    spreadPct: Number(((worst - best) / best * 100).toFixed(1)),
+    bytes: bytes[name],
+    bytesPerMs: Math.round(bytes[name] / best),
+    inputs: work[name].length,
+  };
+  const r = result.grammars[name];
+  console.log(`  ${name.padEnd(9)} ${String(r.ms).padStart(9)} ms   ` +
+    `${String(r.bytesPerMs).padStart(7)} bytes/ms   (spread across reps ${r.spreadPct}%)`);
+}
+
+// A wide spread means the machine was busy, and a comparison against it can
+// only detect regressions bigger than the noise. Say so rather than quietly
+// widening the threshold, because a masked regression looks exactly like a
+// clean result.
+const noisiest = Math.max(...Object.values(result.grammars).map((r) => r.spreadPct));
+if (noisiest > 10) {
+  console.log(`\nnote: reps varied by up to ${noisiest}% — this machine is busy. Anything`);
+  console.log(`      smaller than that is undetectable here; raise --reps or close other work.`);
+}
+
+if (baselineFile) {
+  const base = JSON.parse(fs.readFileSync(baselineFile, 'utf8'));
+  console.log(`\nvs ${relative(process.cwd(), baselineFile)}:\n`);
+  let regressed = false;
+  for (const name of Object.keys(result.grammars)) {
+    const b = base.grammars?.[name];
+    if (!b) continue;
+    const now = result.grammars[name];
+    const delta = (now.ms - b.ms) / b.ms * 100;
+    // A delta smaller than the noise floor, or smaller than this run's own
+    // spread across reps, is not evidence of anything.
+    const meaningful = Math.abs(delta) > NOISE_FLOOR_PCT && Math.abs(delta) > now.spreadPct;
+    const verdict = !meaningful ? 'no change' : delta > 0 ? 'SLOWER' : 'faster';
+    if (meaningful && delta > 0) regressed = true;
+    console.log(`  ${name.padEnd(9)} ${String(b.ms).padStart(9)} -> ${String(now.ms).padStart(9)} ms   ` +
+      `${delta >= 0 ? '+' : ''}${delta.toFixed(1)}%   ${verdict}`);
+  }
+  if (regressed) {
+    console.log('\nA slowdown above the noise floor. Re-run both sides once more before believing it —');
+    console.log('and check the input counts above match, since a differing workload invalidates the comparison.');
+    process.exitCode = 1;
+  }
+}
+
+if (outFile) {
+  fs.writeFileSync(outFile, `${JSON.stringify(result, null, 2)}\n`);
+  console.log(`\nwrote ${relative(process.cwd(), outFile)}`);
+}


### PR DESCRIPTION
No grammar changes. This is tooling and documentation from the corpus work, plus one real hole it exposed.

## The probes never ran in CI

`test/probes/` holds minimal reductions of constructs found in real CFML. `expected.json` records each one's current pass/fail status, and `npm run probe` fails on drift **in either direction** — a gap closing is as loud as a regression.

No workflow invoked it. The harness has been decorative since it was added, and every "probes are green" claim during the corpus work rested on someone remembering to run it by hand.

It now runs in the `test` job on all three platforms, with `npm run testbindings` on the Unix runners. `testbindings` is off Windows deliberately: `node --test bindings/node/*_test.js` relies on shell globbing that `cmd.exe` does not do.

## Fuzz only triggered on scanner paths

Which external tokens are valid depends on the parse state, so a grammar-only change can put a scanner somewhere it has never been asked to scan — and a zero-width token that repeats loops the parser with no scanner edit at all. `common/define-grammar.js` and `cfscript/grammar.js` now trigger the fuzz workflow too. Roughly 30s per dialect, against the 15 minutes a hang costs.

## `scripts/bench.js`

`CORPUS.md` describes the performance methodology — byte-identical inputs per grammar, best of three reps — but the script behind its numbers was never committed, so they could not be reproduced or extended. This is that measurement, and it reproduces the documented byte counts (39.8 MB of cfscript input against the 39.7 MB recorded).

Why it cannot just be a stopwatch on `npm run scan`, stated plainly because getting it wrong produced a confident **"+65% regression" that did not exist**: `scan.js` walks every tree collecting ERROR nodes and locates injected regions *by parsing them*. Both costs move with the error count, so a change that fixes parse errors reads as a huge speed change for reasons unrelated to the parser.

So `bench.js`:

- selects input **by regex, never by parsing**, so the bytes handed to each grammar are identical before and after a change — including script-syntax `.cfc` files, which are the bulk of real cfscript and which a `<cfscript>`-only regex would miss, leaving the number measuring a tenth of the workload
- reads and slices everything up front; times only `parser.parse()`
- reports **best of N reps, not the mean** — runner noise only ever makes a rep slower — and prints the spread so you can see whether the machine was quiet
- treats a delta below 3%, or below the run's own spread, as no change, and warns outright when the spread is wide enough to mask a real regression

```
npm run bench -- corpus --out before.json
npm run bench -- corpus --baseline before.json
```

Verified by comparing a build against itself: −2.1%, −1.4%, −5.8% across the three grammars, all correctly reported as no change.

## `CLAUDE.md` corrections

Five things in it were wrong, each of which cost time this round:

| Said | Actually |
|---|---|
| Three grammars share a scanner and grammar base | `cfml`/`cfquery` share `common/define-grammar.js` + `common/scanner.h`; `cfscript` has its own 1,500-line grammar and 500-line scanner. **CFScript exists twice**, and the copies have drifted |
| `src/` is generated, never hand-edited | Only `parser.c`, `grammar.json`, `node-types.json`. `scanner.c` is hand-written everywhere, and in `cfscript` it is the real scanner |
| `test --filter "cfif"` | The flag is `-i` / `--include` |
| — | `DIALECT=… npm run build` skips the native addon rebuild, so anything using the Node bindings afterwards silently tests the previous parser |
| "Ignore unnecessary conflicts" | Prune them — a stale declaration hides a real ambiguity behind a warning nobody reads, which is what 8140ed6 acted on |

Also documents the three testing layers and what each catches that the others miss.

## `.claude/skills/parse-gap/`

The workflow for making a construct parse: reproduce small, work out which grammar owns it, expect the lexer to fight you, run the gate, land it with the docs updated. Two reference files carry the weight:

- **`references/hazards.md`** — each way this grammar has actually broken, named with the change that triggered it. Keyword extraction being lexical is the recurring one: it broke `var new = 1` when `var local.x` was added, and `loop array=data` when the typed `param` form was. Also `extras` matching inside string literals, widened rules swallowing their neighbours, single-rule conflicts that cannot be declared, and `--update` being a code generator rather than a test.
- **`references/scanner.md`** — the lexer API's three sharp edges (you cannot rewind; `valid_symbols` is the only context you get; zero-width tokens must not repeat), why every consuming loop needs an EOF check, and how to diagnose a hang: attach to the `tree-sitter` child, not the `node` wrapper. That is what found the `queryExecute("` infinite loop.

`.claude/settings.local.json` is gitignored — per-developer permission grants, not shared config.

## Verification

Local only until this PR runs, since `ci.yml` triggers on `pull_request` and pushes to `master`, so a bare feature-branch push exercised nothing:

- `npm test` 299/299, 0 failed parses
- `npm run probe` 28/33 clean, no drift
- `npm run testbindings` 3/3
- `npm run fuzz` green on all three dialects
- `npm run lint` clean
- both workflow files parse as valid YAML with the expected jobs

The one thing I could not check locally is `npm run probe` on the Windows runner. `probe.js:140` normalises keys with `.split(path.sep).join('/')` so they match `expected.json`, but that is reading the code rather than running it — this PR is what actually tests it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015LvkA2w88uREGwh77q3ffN)_