### PR TITLE
Push the release commit and its tag atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Tooling
+
+- Push the release commit and its tag as **one atomic push** rather than two commands. `scripts/release.js` ran `git push` and then `git push origin v<version>`, so the branch landed first and anything that rejected the tag left the version bump on the default branch with nothing tagged and nothing published — the registries still serving the previous version while the repository claims the new one, a state that has to be unpicked by hand. This is not hypothetical: it happened cutting 0.26.33, where the tag push returned HTTP 403 from a credential scoped to `refs/heads/*`, after `master` had already moved. `git push --atomic <remote> HEAD:refs/heads/<branch> refs/tags/v<version>` makes the server take both refs or neither, so a rejected tag leaves the branch untouched and the release is simply retryable. The remote and branch are derived from the upstream the script already requires to exist, so a release cut from a branch whose name differs from its remote's still pushes to the right place. Verified both ways against a local bare repository with a `pre-receive` hook that rejects `refs/tags/*`: non-atomic advances the branch and loses the tag, atomic leaves the branch exactly where it was, and both refs land once the hook is removed
+
 ## [0.26.33]
 
 ### cfml & cfscript

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -242,10 +242,23 @@ async function release() {
   run(`git tag "v${version}"`);
 
   // 8. Push
+  //
+  // One atomic push, not a branch push followed by a tag push. As two commands
+  // the branch lands first, so anything that rejects the tag — a protected-tag
+  // ruleset, a credential scoped to `refs/heads/*`, a network drop — leaves the
+  // version bump on the default branch with nothing tagged and nothing
+  // published, which is a state you have to unpick by hand. `--atomic` makes
+  // the server take both refs or neither, so a rejected tag leaves the branch
+  // untouched and the release simply retryable. The remote and branch come from
+  // the upstream this script has already required to exist.
   await confirm('==> Push commit and tag?');
   if (ghUser) run(`gh auth switch --user ${ghUser}`);
-  run('git push');
-  run(`git push origin "v${version}"`);
+  const upstream = execSync('git rev-parse --abbrev-ref --symbolic-full-name @{u}', {
+    cwd: root, encoding: 'utf8',
+  }).trim();
+  const remote = upstream.slice(0, upstream.indexOf('/'));
+  const branch = upstream.slice(upstream.indexOf('/') + 1);
+  run(`git push --atomic ${remote} HEAD:refs/heads/${branch} refs/tags/v${version}`);
 
   console.log(`\n==> Done! v${version} released.`);
   console.log('    npm and crates.io publish will be handled by the GitHub Release workflow.');


### PR DESCRIPTION
`scripts/release.js` pushed in two commands:

```js
run('git push');
run(`git push origin "v${version}"`);
```

The branch lands first, so anything that rejects the tag leaves the version bump on the default branch with nothing tagged and nothing published — the registries still serving the previous version while the repository claims the new one, and unpicking it is manual.

**This is what happened cutting 0.26.33 in this repository.** The tag push returned HTTP 403 from a credential scoped to `refs/heads/*`, after `master` had already moved. `e2759ab` is on master, there is no `v0.26.33` tag, and `release.yml` never fired.

## The change

```js
run(`git push --atomic ${remote} HEAD:refs/heads/${branch} refs/tags/v${version}`);
```

`--atomic` makes the server take both refs or neither, so a rejected tag leaves the branch untouched and the release is simply retryable.

`remote` and `branch` are derived from the upstream the script already requires to exist (it checks `HEAD..@{u}` earlier), rather than hardcoding `origin` and the current branch name. That way a release cut from a branch whose local name differs from its remote's still pushes to the right ref; the split handles slashes in branch names (`origin/feature/x` → `origin` + `feature/x`).

## Verification

Against a local bare repository with a `pre-receive` hook rejecting `refs/tags/*`:

| | branch after a rejected tag |
|---|---|
| two commands (before) | **advanced** — tag lost, half-released |
| `--atomic` (after) | **unchanged**, on its original SHA |

And with the hook removed, the atomic push lands both refs — so this is not just failing safe, it still works.

`npm run lint` clean.

## Note on what this does not fix

0.26.33 is still in the half-released state this prevents. That needs `git push origin v0.26.33` from somewhere with tag permission; this change only stops it happening again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MS4nF7L6VEPMEVp3sxfzDG)_