### PR TITLE
Sync highlight queries with zed-cfml's newer copies

### DIFF
--- a/cfml/queries/highlights.scm
+++ b/cfml/queries/highlights.scm
@@ -1,59 +1,92 @@
 ; Document and structure (from Lucee-style rules)
 (program) @document
+
 (doctype) @doctype
+
 (entity) @constant
+
 (html_text) @text
 
+(cdata_section
+  ["<![CDATA[" "]]>"] @punctuation.special)
+
+(cdata_text) @text
+
 (erroneous_end_tag_name) @tag.error
+
 (erroneous_cf_end_tag_name) @tag.error
+
 (attribute_name) @attribute
+
 (cf_attribute_name) @attribute
+
 (attribute_value) @string
+
 (script_text) @embedded
+
 (style_text) @embedded
+
 (start_tag) @tag
+
 (end_tag) @tag
+
 (self_closing_tag) @tag
+
 (cf_selfclose_tag) @tag
+
 (cf_start_tag_with_selfclose) @tag
+
 (cf_output_tag) @tag
+
 (cf_function_tag) @tag
+
 (cf_script_tag) @tag
+
 (cf_start_tag) @tag
+
 (cf_end_tag) @tag
+
 (cf_if_tag) @tag
+
 (cf_query_tag) @tag
+
+(cf_savecontent_tag) @tag
+
 (cf_else_tag) @tag
+
 (cf_elseif_tag) @tag
+
 (cf_return_tag) @tag
+
 (cf_xml_tag) @tag
+
 (cf_component_open_tag) @tag
+
 (cf_component_close_tag) @tag
 
 (tag_name) @tag
+
 (cf_tag_name) @tag
 
 ; Variables
 ;----------
-
 (identifier) @variable
 
 ; CFML scopes
 ;-------------
-
 ((identifier) @variable.builtin
  (#match? @variable.builtin "^(?i)(APPLICATION|ARGUMENTS|CGI|CLIENT|COOKIE|FORM|LOCAL|REQUEST|SERVER|SESSION|THIS|URL|VARIABLES)$"))
 
 ; Properties
 ;-----------
-
 (property_identifier) @property
 
 (shorthand_property_identifier) @property
 
+(shorthand_property_identifier_pattern) @property
+
 ; Function and method definitions
 ;--------------------------------
-
 (function_expression
   name: (identifier) @function) @definition.function
 
@@ -113,10 +146,9 @@
 
 ; Function and method calls
 ;--------------------------
-
 (call_expression
   function: (identifier) @function.builtin
-  (#match? @function.builtin "^(?i)(abs|acos|addsoaprequestheader|addsoapresponseheader|aigetmetadata|aihas|ajaxlink|ajaxonload|applicationpathcacheclear|applicationstarttime|applicationstop|argon2checkhash|array|arrayappend|arrayavg|arrayclear|arraycontains|arraycontainsnocase|arraydelete|arraydeleteat|arraydeletenocase|arrayeach|arrayevery|arrayfilter|arrayfind|arrayfindall|arrayfindallnocase|arrayfindnocase|arrayfirst|arrayindexexists|arrayinsertat|arrayisdefined|arrayisempty|arraylast|arraylen|arraymap|arraymax|arraymedian|arraymerge|arraymid|arraymin|arraynew|arraypop|arrayprepend|arraypush|arrayreduce|arrayremoveduplicates|arrayresize|arrayreverse|arrayset|arrayshift|arrayslice|arraysome|arraysort|arraysplice|arraysum|arrayswap|arraytolist|arraytostruct|arrayunshift|asc|asin|astfrompath|astfromstring|atn|beat|binarydecode|binaryencode|bitand|bitmaskclear|bitmaskread|bitmaskset|bitnot|bitor|bitshln|bitshrn|bitxor|booleanformat|bundleinfo|cacheclear|cachecount|cachedelete|cacheget|cachegetall|cachegetallids|cachegetdefaultcachename|cachegetmetadata|cachegetproperties|cacheidexists|cachekeyexists|cacheput|cacheregionexists|cacheregionnew|cacheregionremove|cacheremove|cacheremoveall|cachesetproperties|callstackdump|callstackget|canonicalize|ceiling|cfusion_decrypt|cfusion_encrypt|charsetdecode|charsetencode|chr|cjustify|cleartimezone|collectioneach|collectionevery|collectionfilter|collectionmap|collectionreduce|collectionsome|compare|comparenocase|componentcacheclear|componentcachelist|componentinfo|componentlistpackage|compress|configimport|configtranslate|contractpath|cos|createaisession|createdate|createdatetime|createdynamicproxy|createguid|createobject|createodbcdate|createodbcdatetime|createodbctime|createtime|createtimespan|createulid|createuniqueid|createuuid|createwebsocketclient|csrfgeneratetoken|csrfverifytoken|ctcacheclear|ctcachelist|datasourceflushmetacache|dateadd|datecompare|dateconvert|datediff|dateformat|datepart|datetimeformat|day|dayofweek|dayofweekasstring|dayofweekshortasstring|dayofyear|daysinmonth|daysinyear|dbpoolclear|de|debugadd|decimalformat|decodeforhtml|decodefromurl|decrementvalue|decrypt|decryptbinary|deleteclientvariable|deserializejson|directorycopy|directorycreate|directorydelete|directoryexists|directoryinfo|directorylist|directoryrename|dollarformat|dump|duplicate|each|ec2describeinstances|echo|empty|encodeforcss|encodefordn|encodeforhtml|encodeforhtmlattribute|encodeforjavascript|encodeforldap|encodeforsql|encodeforurl|encodeforxml|encodeforxmlattribute|encodeforxpath|encrypt|encryptbinary|entitydelete|entityload|entityloadbyexample|entityloadbypk|entitymerge|entitynamearray|entitynamelist|entitynew|entityreload|entitysave|entitytoquery|esapidecode|esapiencode|evaluate|exp|expandpath|extensionexists|extensioninfo|extensionlist|extract|fileappend|fileclose|filecopy|filedelete|fileexists|filegetmimetype|fileinfo|fileiseof|filemodetosymbolic|filemove|fileopen|fileread|filereadbinary|filereadline|fileseek|filesetaccessmode|filesetattribute|filesetlastmodified|fileskipbytes|filetouch|fileupload|fileuploadall|filewrite|filewriteline|find|findlast|findlastnocase|findnocase|findoneof|firstdayofmonth|fix|floor|formatbasen|generatesecretkey|getapplicationmetadata|getapplicationsettings|getauthuser|getbasetagdata|getbasetaglist|getbasetemplatepath|getcanonicalpath|getclientvariableslist|getcomponentmetadata|getcontextroot|getcurrenttemplatepath|getdirectoryfrompath|getencoding|getfilefrompath|getfileinfo|getfunctioncalledname|getfunctionlist|gethttprequestdata|gethttptimestring|getlocale|getlocaledisplayname|getlocaleinfo|getlocalhostip|getmetadata|getnumericdate|getpagecontext|getprofilesections|getprofilestring|getreadableimageformats|getsoaprequest|getsoaprequestheader|getsoapresponse|getsoapresponseheader|getsystemfreememory|getsystemtotalmemory|gettempdirectory|gettempfile|gettickcount|gettimezoneinfo|gettoken|getuserroles|getvfsmetadata|getwriteableimageformats|hash|hash40|hmac|hour|htmlcodeformat|htmleditformat|iif|imageaddborder|imageblur|imageclearrect|imagecopy|imagecrop|imagedrawarc|imagedrawbeveledrect|imagedrawcubiccurve|imagedrawline|imagedrawlines|imagedrawoval|imagedrawpoint|imagedrawquadraticcurve|imagedrawrect|imagedrawroundrect|imagedrawtext|imageflip|imagegetblob|imagegetbufferedimage|imagegetexifmetadata|imagegetexiftag|imagegetheight|imagegetiptcmetadata|imagegetwidth|imagegrayscale|imageinfo|imagenegative|imagenew|imageoverlay|imagepaste|imageread|imagereadbase64|imageresize|imagerotate|imagerotatedrawingaxis|imagescaletofit|imagesetantialiasing|imagesetbackgroundcolor|imagesetdrawingcolor|imagesetdrawingstroke|imagesetdrawingtransparency|imageshear|imagesheardrawingaxis|imagetranslate|imagetranslatedrawingaxis|imagewrite|imagewritebase64|imagexordrawingmode|incrementvalue|inputbasen|insert|int|invoke|isarray|isbinary|isboolean|isclosure|iscustomfunction|isdate|isdebugmode|isdefined|isempty|isfileobject|isimage|isimagefile|isinstanceof|isipv6|isjson|isleapyear|islocalhost|isnull|isnumeric|isnumericdate|isobject|ispdfobject|isquery|issimplevalue|issoaprequest|isstruct|isuserinanyrole|isuserinrole|isuserloggedin|isvalid|iswddx|isxml|isxmlattribute|isxmldoc|isxmlelem|isxmlnode|isxmlroot|javacast|jsstringformat|lcase|left|len|listappend|listchangedelims|listcompact|listcontains|listcontainsnocase|listdeleteat|listeach|listevery|listfilter|listfind|listfindnocase|listfirst|listgetat|listinsertat|listitemtrim|listlast|listlen|listmap|listprepend|listqualify|listreduce|listremoveduplicates|listrest|listsetat|listsome|listsort|listtoarray|listtrim|listvaluecount|listvaluecountnocase|ljustify|location|log|log10|lscurrencyformat|lsdateformat|lsdatetimeformat|lseurocurrencyformat|lsiscurrency|lsisdate|lsisnumeric|lsnumberformat|lsparsecurrency|lsparsedatetime|lsparseeurocurrency|lsparsenumber|lstimeformat|ltrim|max|mid|min|minute|month|monthasstring|monthshortasstring|now|nullvalue|numberformat|objectequals|objectload|objectsave|ormclearsession|ormcloseallsessions|ormclosesession|ormevictcollection|ormevictentity|ormevictqueries|ormexecutequery|ormflush|ormgetsession|ormgetsessionfactory|ormreload|paragraphformat|parameterexists|parsedatetime|parsenumber|pi|precisionevaluate|preservesinglequotes|quarter|queryaddcolumn|queryaddrow|queryclose|querycolumnarray|querycolumncount|querycolumndata|querycolumnexists|querycolumnlist|queryconvertforgrid|querycurrentrow|querydeletecolumn|querydeleterow|queryeach|queryevery|queryexecute|queryfilter|querygetcell|querygetrow|querykeyexists|querymap|querynew|queryrecordcount|queryreduce|queryrenamecolumn|queryreverse|queryrowdata|querysetcell|queryslice|querysome|querysort|quotedvaluelist|rand|randomize|randrange|reescape|refind|refindnocase|releasecomobject|rematch|rematchnocase|removechars|repeatstring|replace|replacelist|replacelistnocase|replacenocase|rereplace|rereplacenocase|restdeleteapplication|restinitapplication|restsetresponse|reverse|right|rjustify|round|rtrim|second|sendgatewaymessage|serializejson|sessioninvalidate|sessionrotate|setencoding|setlocale|setprofilestring|setvariable|sgn|sin|sleep|soundex|spanexcluding|spanincluding|sqr|stripcr|structappend|structclear|structcopy|structcount|structdelete|structeach|structevery|structfilter|structfind|structfindkey|structfindvalue|structget|structinsert|structisempty|structkeyarray|structkeyexists|structkeylist|structkeytranslate|structmap|structnew|structreduce|structsome|structsort|structtosorted|structupdate|tan|threadjoin|threadterminate|throw|timeformat|tobase64|tobinary|tonumeric|toscript|tostring|trace|transactioncommit|transactionrollback|transactionsetsavepoint|trim|ucase|ucfirst|urldecode|urlencodedformat|urlsessionformat|val|valuearray|valuelist|verifyclient|week|wrap|writedump|writelog|writeoutput|xmlchildpos|xmlelemnew|xmlformat|xmlgetnodetype|xmlnew|xmlparse|xmlsearch|xmltransform|xmlvalidate|year|yesnoformat)$"))
+  (#match? @function.builtin "^(?i)(abs|acos|addsoaprequestheader|addsoapresponseheader|aigetmetadata|aihas|ajaxlink|ajaxonload|applicationpathcacheclear|applicationstarttime|applicationstop|argon2checkhash|array|arrayappend|arrayavg|arrayclear|arraycontains|arraycontainsnocase|arraydelete|arraydeleteat|arraydeletenocase|arrayeach|arrayevery|arrayfilter|arrayfind|arrayfindall|arrayfindallnocase|arrayfindnocase|arrayfirst|arrayindexexists|arrayinsertat|arrayisdefined|arrayisempty|arraylast|arraylen|arraymap|arraymax|arraymedian|arraymerge|arraymid|arraymin|arraynew|arraypop|arrayprepend|arraypush|arrayreduce|arrayremoveduplicates|arrayresize|arrayreverse|arrayset|arrayshift|arrayslice|arraysome|arraysort|arraysplice|arraysum|arrayswap|arraytolist|arraytostruct|arrayunshift|asc|asin|astfrompath|astfromstring|atn|beat|binarydecode|binaryencode|bitand|bitmaskclear|bitmaskread|bitmaskset|bitnot|bitor|bitshln|bitshrn|bitxor|booleanformat|bundleinfo|cacheclear|cachecount|cachedelete|cacheget|cachegetall|cachegetallids|cachegetdefaultcachename|cachegetmetadata|cachegetproperties|cacheidexists|cachekeyexists|cacheput|cacheregionexists|cacheregionnew|cacheregionremove|cacheremove|cacheremoveall|cachesetproperties|callstackdump|callstackget|canonicalize|ceiling|cfusion_decrypt|cfusion_encrypt|charsetdecode|charsetencode|chr|cjustify|cleartimezone|collectioneach|collectionevery|collectionfilter|collectionmap|collectionreduce|collectionsome|compare|comparenocase|componentcacheclear|componentcachelist|componentinfo|componentlistpackage|compress|configimport|configtranslate|contractpath|cos|createaisession|createdate|createdatetime|createdynamicproxy|createguid|createobject|createodbcdate|createodbcdatetime|createodbctime|createtime|createtimespan|createulid|createuniqueid|createuuid|createwebsocketclient|csrfgeneratetoken|csrfverifytoken|ctcacheclear|ctcachelist|datasourceflushmetacache|dateadd|datecompare|dateconvert|datediff|dateformat|datepart|datetimeformat|day|dayofweek|dayofweekasstring|dayofweekshortasstring|dayofyear|daysinmonth|daysinyear|dbpoolclear|de|debugadd|decimalformat|decodeforhtml|decodefromurl|decrementvalue|decrypt|decryptbinary|deleteclientvariable|deserializejson|directorycopy|directorycreate|directorydelete|directoryexists|directoryinfo|directorylist|directoryrename|dollarformat|dump|duplicate|each|ec2describeinstances|echo|empty|encodeforcss|encodefordn|encodeforhtml|encodeforhtmlattribute|encodeforjavascript|encodeforldap|encodeforsql|encodeforurl|encodeforxml|encodeforxmlattribute|encodeforxpath|encrypt|encryptbinary|entitydelete|entityload|entityloadbyexample|entityloadbypk|entitymerge|entitynamearray|entitynamelist|entitynew|entityreload|entitysave|entitytoquery|esapidecode|esapiencode|evaluate|exp|expandpath|extensionexists|extensioninfo|extensionlist|extract|fileappend|fileclose|filecopy|filedelete|fileexists|filegetmimetype|fileinfo|fileiseof|filemodetosymbolic|filemove|fileopen|fileread|filereadbinary|filereadline|fileseek|filesetaccessmode|filesetattribute|filesetlastmodified|fileskipbytes|filetouch|fileupload|fileuploadall|filewrite|filewriteline|find|findlast|findlastnocase|findnocase|findoneof|firstdayofmonth|fix|floor|formatbasen|gatewayaction|gatewaystate|generate3deskey|generateargon2hash|generatepbkdfkey|generatersakeys|generatesecretkey|getapplicationmetadata|getapplicationsettings|getauthuser|getbasetagdata|getbasetaglist|getbasetemplatepath|getbuiltinfunction|getcanonicalpath|getclasspath|getclientvariableslist|getcomponentmetadata|getcomponentstaticscope|getcontextinfo|getcontextroot|getcpuusage|getcurrentcontext|getcurrenttemplatepath|getdirectoryfrompath|getencoding|getfilefrompath|getfileinfo|getfreespace|getfunctioncalledname|getfunctiondata|getfunctionkeywords|getfunctionlist|gethttprequestdata|gethttprequestheaders|gethttptimestring|getk2serverdoccount|getk2serverdoccountlimit|getlocale|getlocaledisplayname|getlocaleinfo|getlocalhostip|getluceeid|getmemoryusage|getmetadata|getmetricdata|getnumericdate|getpagecontext|getprinterinfo|getprinterlist|getprofilesections|getprofilestring|getpropertyfile|getpropertystring|getreadableimageformats|getsoaprequest|getsoaprequestheader|getsoapresponse|getsoapresponseheader|getsystemfreememory|getsystemmetrics|getsystemproporenvvar|getsystemtotalmemory|gettagdata|gettaglist|gettempdirectory|gettempfile|gettemplatepath|gettickcount|gettimezone|gettimezoneinfo|gettoken|gettotalspace|getuserroles|getvariable|getvfsmetadata|getwriteableimageformats|guarddecode|guardencode|hash|hash40|hmac|hour|htmlcodeformat|htmleditformat|htmlparse|iif|imageaddborder|imageblur|imagecaptcha|imageclearrect|imagecoderinfo|imagecopy|imagecrop|imagedrawarc|imagedrawbeveledrect|imagedrawcubiccurve|imagedrawimage|imagedrawline|imagedrawlines|imagedrawoval|imagedrawpoint|imagedrawquadraticcurve|imagedrawrect|imagedrawroundrect|imagedrawtext|imagefilter|imagefiltercolormap|imagefiltercurves|imagefilterkernel|imagefilterwarpgrid|imageflip|imagefonts|imageformats|imagegetblob|imagegetbufferedimage|imagegetexifmetadata|imagegetexiftag|imagegetheight|imagegetiptcmetadata|imagegetwidth|imagegrayscale|imageinfo|imagenegative|imagenew|imageoverlay|imagepaste|imageread|imagereadbase64|imageresize|imagerotate|imagerotatedrawingaxis|imagescaletofit|imagesetantialiasing|imagesetbackgroundcolor|imagesetdrawingalpha|imagesetdrawingcolor|imagesetdrawingstroke|imagesetdrawingtransparency|imagesharpen|imageshear|imagesheardrawingaxis|imagetranslate|imagetranslatedrawingaxis|imagewrite|imagewritebase64|imagewritetobrowser|imagexordrawingmode|incrementvalue|inputbasen|inquiryaisession|insert|inspecttemplates|int|internalrequest|interruptthread|invoke|isarray|isbinary|isboolean|isclosure|iscustomfunction|isdate|isdebugmode|isdefined|isempty|isfileobject|isflushed|isimage|isimagefile|isinstanceof|isinthread|isipinrange|isipv6|isjson|isleapyear|islocalhost|isnotmap|isnull|isnumeric|isnumericdate|isobject|ispdfobject|isquery|issimplevalue|issoaprequest|isstruct|isthreadinterrupted|isuserinanyrole|isuserinrole|isuserloggedin|isvalid|isvideofile|iswddx|iswithintransaction|isxml|isxmlattribute|isxmldoc|isxmlelem|isxmlnode|isxmlroot|iszipfile|javacast|jsstringformat|lcase|left|len|listappend|listavg|listchangedelims|listcompact|listcontains|listcontainsnocase|listdeleteat|listeach|listevery|listfilter|listfind|listfindnocase|listfirst|listgetat|listgetduplicates|listindexexists|listinsertat|listitemtrim|listlast|listlen|listmap|listprepend|listqualifiedtoarray|listqualify|listreduce|listremoveduplicates|listrest|listsetat|listsome|listsort|listtoarray|listtrim|listvaluecount|listvaluecountnocase|ljustify|loadaisession|location|log|log10|logallthreads|lscurrencyformat|lsdateformat|lsdatetimeformat|lsdayofweek|lseurocurrencyformat|lsiscurrency|lsisdate|lsisnumeric|lslcase|lsnumberformat|lsparsecurrency|lsparsedatetime|lsparseeurocurrency|lsparsenumber|lstimeformat|lsucase|lsweek|ltrim|luceeaigetmetadata|luceeaihas|luceecreateaisession|luceeinquiryaisession|manifestread|markdowntohtml|maveninfo|mavenload|max|metaphone|mid|millisecond|min|minute|month|monthasstring|monthshortasstring|newline|now|nowserver|nullvalue|numberformat|objectequals|objectload|objectsave|ormclearsession|ormcloseallsessions|ormclosesession|ormevictcollection|ormevictentity|ormevictqueries|ormexecutequery|ormflush|ormgetsession|ormgetsessionfactory|ormreload|pagepoolclear|pagepoollist|paragraphformat|parameterexists|parsedatetime|parsenumber|pi|precisionevaluate|preservesinglequotes|quarter|query|queryaddcolumn|queryaddrow|queryappend|queryclear|queryclose|querycolumnarray|querycolumncount|querycolumndata|querycolumnexists|querycolumnlist|queryconvertforgrid|querycurrentrow|querydeletecolumn|querydeleterow|queryeach|queryevery|queryexecute|queryfilter|querygetcell|querygetcellbyindex|querygetrow|queryinsertat|queryisempty|querykeyexists|querylazy|querymap|querynew|queryprepend|queryrecordcount|queryreduce|queryrenamecolumn|queryreverse|queryrowbyindex|queryrowdata|queryrowdatabyindex|queryrowswap|querysetcell|querysetrow|queryslice|querysome|querysort|querytostruct|quotedvaluelist|rand|randomize|randrange|rediscommand|rediscommandlowpriority|redisconnectionpoolinfo|reescape|refind|refindnocase|releasecomobject|rematch|rematchnocase|removechars|render|repeatstring|replace|replacelist|replacelistnocase|replacenocase|rereplace|rereplacenocase|restdeleteapplication|restinitapplication|restsetresponse|reverse|right|rjustify|round|rtrim|runasync|s3addacl|s3clearbucket|s3copy|s3createbucket|s3delete|s3deletebucket|s3download|s3exists|s3generatepresignedurl|s3generateuri|s3getacl|s3getmetadata|s3getversioninfo|s3listbucket|s3listbuckets|s3move|s3read|s3readbinary|s3setacl|s3setmetadata|s3upload|s3write|sanitize|sanitizehtml|second|secretproviderget|sendgatewaymessage|serialize|serializeaisession|serializejson|sessioncommit|sessionexists|sessioninvalidate|sessionrotate|sessionstarttime|setencoding|setlocale|setprofilestring|setpropertystring|settimezone|setvariable|sgn|sin|sizeof|sleep|soundex|spanexcluding|spanincluding|spreadsheetnew|sqr|sslcertificateinstall|sslcertificatelist|storeaddacl|storegetacl|storegetmetadata|storesetacl|storesetmetadata|stringeach|stringevery|stringfilter|stringlen|stringmap|stringreduce|stringsome|stringsort|stripcr|structappend|structclear|structcopy|structcount|structdelete|structeach|structevery|structfilter|structfind|structfindkey|structfindvalue|structget|structinsert|structisempty|structkeyarray|structkeyexists|structkeylist|structkeytranslate|structmap|structnew|structreduce|structsome|structsort|structtosorted|structupdate|structvaluearray|systemcacheclear|systemoutput|tan|threaddata|threadinterrupt|threadinterrupted|threadjoin|threadterminate|throw|timeformat|tobase64|tobinary|tonumeric|toscript|tostring|trace|transactioncommit|transactionrollback|transactionsetsavepoint|trim|trimwhitespace|truefalseformat|ucase|ucfirst|unserializejava|urldecode|urlencode|urlencodedformat|urlsessionformat|val|validatejson|valuearray|valuelist|valueref|verifyclient|webservicenew|websocketinfo|week|wrap|writedump|writelog|writeoutput|xmlchildpos|xmlelemnew|xmlformat|xmlgetnodetype|xmlnew|xmlparse|xmlsearch|xmltransform|xmlvalidate|year|yesnoformat)$"))
 
 (call_expression
   function: (identifier) @function.call)
@@ -134,6 +166,7 @@
   (#eq? @variable.builtin "self"))
 
 (this) @variable.builtin
+
 (super) @variable.builtin
 
 (cf_var) @keyword
@@ -160,10 +193,15 @@
   (#eq? @keyword.directive "use strict"))
 
 (string) @string
+
 (text) @string
+
 (hash_empty) @punctuation.special
 
+(hash_single) @punctuation.special
+
 (regex_pattern) @string.regexp
+
 (regex_flags) @character.special
 
 (regex
@@ -184,17 +222,13 @@
 
 ; Types
 ;------
-
 (parameter_type) @type
-; `User[] function getUsers()` — one token, so the anonymous "[" / "]"
-; rule below cannot reach it.
-(array_return_suffix) @punctuation.bracket
+
 (catch_clause
   type: (catch_type) @type)
 
 ; Imports
 ;--------
-
 (import_path
   (identifier) @module)
 
@@ -263,6 +297,12 @@
   "&&="
   "||="
   "??="
+  "<="
+  "<>"
+  "<<"
+  ">="
+  ">>"
+  ">>>"
 ] @operator
 
 [
@@ -304,3 +344,16 @@
   ">"
   "</"
 ] @punctuation.bracket
+
+; Function and method calls
+;--------------------------
+(call_expression
+  function: (identifier) @function.builtin
+  (#match? @function.builtin "^(?i)(abs|acos|addsoaprequestheader|addsoapresponseheader|aigetmetadata|aihas|ajaxlink|ajaxonload|applicationpathcacheclear|applicationstarttime|applicationstop|argon2checkhash|array|arrayappend|arrayavg|arrayclear|arraycontains|arraycontainsnocase|arraydelete|arraydeleteat|arraydeletenocase|arrayeach|arrayevery|arrayfilter|arrayfind|arrayfindall|arrayfindallnocase|arrayfindnocase|arrayfirst|arrayindexexists|arrayinsertat|arrayisdefined|arrayisempty|arraylast|arraylen|arraymap|arraymax|arraymedian|arraymerge|arraymid|arraymin|arraynew|arraypop|arrayprepend|arraypush|arrayreduce|arrayremoveduplicates|arrayresize|arrayreverse|arrayset|arrayshift|arrayslice|arraysome|arraysort|arraysplice|arraysum|arrayswap|arraytolist|arraytostruct|arrayunshift|asc|asin|astfrompath|astfromstring|atn|beat|binarydecode|binaryencode|bitand|bitmaskclear|bitmaskread|bitmaskset|bitnot|bitor|bitshln|bitshrn|bitxor|booleanformat|bundleinfo|cacheclear|cachecount|cachedelete|cacheget|cachegetall|cachegetallids|cachegetdefaultcachename|cachegetmetadata|cachegetproperties|cacheidexists|cachekeyexists|cacheput|cacheregionexists|cacheregionnew|cacheregionremove|cacheremove|cacheremoveall|cachesetproperties|callstackdump|callstackget|canonicalize|ceiling|cfusion_decrypt|cfusion_encrypt|charsetdecode|charsetencode|chr|cjustify|cleartimezone|collectioneach|collectionevery|collectionfilter|collectionmap|collectionreduce|collectionsome|compare|comparenocase|componentcacheclear|componentcachelist|componentinfo|componentlistpackage|compress|configimport|configtranslate|contractpath|cos|createaisession|createdate|createdatetime|createdynamicproxy|createguid|createobject|createodbcdate|createodbcdatetime|createodbctime|createtime|createtimespan|createulid|createuniqueid|createuuid|createwebsocketclient|csrfgeneratetoken|csrfverifytoken|ctcacheclear|ctcachelist|datasourceflushmetacache|dateadd|datecompare|dateconvert|datediff|dateformat|datepart|datetimeformat|day|dayofweek|dayofweekasstring|dayofweekshortasstring|dayofyear|daysinmonth|daysinyear|dbpoolclear|de|debugadd|decimalformat|decodeforhtml|decodefromurl|decrementvalue|decrypt|decryptbinary|deleteclientvariable|deserializejson|directorycopy|directorycreate|directorydelete|directoryexists|directoryinfo|directorylist|directoryrename|dollarformat|dump|duplicate|each|ec2describeinstances|echo|empty|encodeforcss|encodefordn|encodeforhtml|encodeforhtmlattribute|encodeforjavascript|encodeforldap|encodeforsql|encodeforurl|encodeforxml|encodeforxmlattribute|encodeforxpath|encrypt|encryptbinary|entitydelete|entityload|entityloadbyexample|entityloadbypk|entitymerge|entitynamearray|entitynamelist|entitynew|entityreload|entitysave|entitytoquery|esapidecode|esapiencode|evaluate|exp|expandpath|extensionexists|extensioninfo|extensionlist|extract|fileappend|fileclose|filecopy|filedelete|fileexists|filegetmimetype|fileinfo|fileiseof|filemodetosymbolic|filemove|fileopen|fileread|filereadbinary|filereadline|fileseek|filesetaccessmode|filesetattribute|filesetlastmodified|fileskipbytes|filetouch|fileupload|fileuploadall|filewrite|filewriteline|find|findlast|findlastnocase|findnocase|findoneof|firstdayofmonth|fix|floor|formatbasen|generatesecretkey|getapplicationmetadata|getapplicationsettings|getauthuser|getbasetagdata|getbasetaglist|getbasetemplatepath|getcanonicalpath|getclientvariableslist|getcomponentmetadata|getcontextroot|getcurrenttemplatepath|getdirectoryfrompath|getencoding|getfilefrompath|getfileinfo|getfunctioncalledname|getfunctionlist|gethttprequestdata|gethttptimestring|getlocale|getlocaledisplayname|getlocaleinfo|getlocalhostip|getmetadata|getnumericdate|getpagecontext|getprofilesections|getprofilestring|getreadableimageformats|getsoaprequest|getsoaprequestheader|getsoapresponse|getsoapresponseheader|getsystemfreememory|getsystemtotalmemory|gettempdirectory|gettempfile|gettickcount|gettimezoneinfo|gettoken|getuserroles|getvfsmetadata|getwriteableimageformats|hash|hash40|hmac|hour|htmlcodeformat|htmleditformat|iif|imageaddborder|imageblur|imageclearrect|imagecopy|imagecrop|imagedrawarc|imagedrawbeveledrect|imagedrawcubiccurve|imagedrawline|imagedrawlines|imagedrawoval|imagedrawpoint|imagedrawquadraticcurve|imagedrawrect|imagedrawroundrect|imagedrawtext|imageflip|imagegetblob|imagegetbufferedimage|imagegetexifmetadata|imagegetexiftag|imagegetheight|imagegetiptcmetadata|imagegetwidth|imagegrayscale|imageinfo|imagenegative|imagenew|imageoverlay|imagepaste|imageread|imagereadbase64|imageresize|imagerotate|imagerotatedrawingaxis|imagescaletofit|imagesetantialiasing|imagesetbackgroundcolor|imagesetdrawingcolor|imagesetdrawingstroke|imagesetdrawingtransparency|imageshear|imagesheardrawingaxis|imagetranslate|imagetranslatedrawingaxis|imagewrite|imagewritebase64|imagexordrawingmode|incrementvalue|inputbasen|insert|int|invoke|isarray|isbinary|isboolean|isclosure|iscustomfunction|isdate|isdebugmode|isdefined|isempty|isfileobject|isimage|isimagefile|isinstanceof|isipv6|isjson|isleapyear|islocalhost|isnull|isnumeric|isnumericdate|isobject|ispdfobject|isquery|issimplevalue|issoaprequest|isstruct|isuserinanyrole|isuserinrole|isuserloggedin|isvalid|iswddx|isxml|isxmlattribute|isxmldoc|isxmlelem|isxmlnode|isxmlroot|javacast|jsstringformat|lcase|left|len|listappend|listchangedelims|listcompact|listcontains|listcontainsnocase|listdeleteat|listeach|listevery|listfilter|listfind|listfindnocase|listfirst|listgetat|listinsertat|listitemtrim|listlast|listlen|listmap|listprepend|listqualify|listreduce|listremoveduplicates|listrest|listsetat|listsome|listsort|listtoarray|listtrim|listvaluecount|listvaluecountnocase|ljustify|location|log|log10|lscurrencyformat|lsdateformat|lsdatetimeformat|lseurocurrencyformat|lsiscurrency|lsisdate|lsisnumeric|lsnumberformat|lsparsecurrency|lsparsedatetime|lsparseeurocurrency|lsparsenumber|lstimeformat|ltrim|max|mid|min|minute|month|monthasstring|monthshortasstring|now|nullvalue|numberformat|objectequals|objectload|objectsave|ormclearsession|ormcloseallsessions|ormclosesession|ormevictcollection|ormevictentity|ormevictqueries|ormexecutequery|ormflush|ormgetsession|ormgetsessionfactory|ormreload|paragraphformat|parameterexists|parsedatetime|parsenumber|pi|precisionevaluate|preservesinglequotes|quarter|queryaddcolumn|queryaddrow|queryclose|querycolumnarray|querycolumncount|querycolumndata|querycolumnexists|querycolumnlist|queryconvertforgrid|querycurrentrow|querydeletecolumn|querydeleterow|queryeach|queryevery|queryexecute|queryfilter|querygetcell|querygetrow|querykeyexists|querymap|querynew|queryrecordcount|queryreduce|queryrenamecolumn|queryreverse|queryrowdata|querysetcell|queryslice|querysome|querysort|quotedvaluelist|rand|randomize|randrange|reescape|refind|refindnocase|releasecomobject|rematch|rematchnocase|removechars|repeatstring|replace|replacelist|replacelistnocase|replacenocase|rereplace|rereplacenocase|restdeleteapplication|restinitapplication|restsetresponse|reverse|right|rjustify|round|rtrim|second|sendgatewaymessage|serializejson|sessioninvalidate|sessionrotate|setencoding|setlocale|setprofilestring|setvariable|sgn|sin|sleep|soundex|spanexcluding|spanincluding|sqr|stripcr|structappend|structclear|structcopy|structcount|structdelete|structeach|structevery|structfilter|structfind|structfindkey|structfindvalue|structget|structinsert|structisempty|structkeyarray|structkeyexists|structkeylist|structkeytranslate|structmap|structnew|structreduce|structsome|structsort|structtosorted|structupdate|tan|threadjoin|threadterminate|throw|timeformat|tobase64|tobinary|tonumeric|toscript|tostring|trace|transactioncommit|transactionrollback|transactionsetsavepoint|trim|ucase|ucfirst|urldecode|urlencodedformat|urlsessionformat|val|valuearray|valuelist|verifyclient|week|wrap|writedump|writelog|writeoutput|xmlchildpos|xmlelemnew|xmlformat|xmlgetnodetype|xmlnew|xmlparse|xmlsearch|xmltransform|xmlvalidate|year|yesnoformat)$"))
+
+; `User[] function getUsers()` — one token, so the anonymous "[" / "]"
+; rule below cannot reach it.
+(array_return_suffix) @punctuation.bracket
+
+; Lucee object selector, e.g. `new java:java.io.File(...)`
+(type_prefix) @keyword

--- a/cfquery/queries/highlights.scm
+++ b/cfquery/queries/highlights.scm
@@ -1,24 +1,49 @@
 ; CF tags
 (erroneous_cf_end_tag_name) @tag.error
+
 (cf_attribute_name) @attribute
+
 (attribute_value) @string
+
 (cf_selfclose_tag) @tag
+
 (cf_start_tag_with_selfclose) @tag
+
 (cf_set_tag) @tag
+
 (cf_if_tag) @tag
+
 (cf_else_tag) @tag
+
 (cf_elseif_tag) @tag
+
 (cf_start_tag) @tag
+
 (cf_end_tag) @tag
+
 (cf_tag) @tag
+
+(cf_output_tag) @tag
+
+(cf_return_tag) @tag
+
 (cf_tag_name) @tag
 
 ; Variables
 (identifier) @variable
 
+; CFML scopes
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^(?i)(APPLICATION|ARGUMENTS|CGI|CLIENT|COOKIE|FORM|LOCAL|REQUEST|SERVER|SESSION|THIS|URL|VARIABLES)$"))
+
 ; Properties
 (property_identifier) @property
+
 (shorthand_property_identifier) @property
+
+(shorthand_property_identifier_pattern) @property
+
+(private_property_identifier) @property
 
 ; Function and method definitions
 (function_expression
@@ -58,6 +83,12 @@
   right: [(function_expression) (arrow_function)])
 
 ; Function and method calls
+; Lucee built-in functions - highlight as builtin
+(call_expression
+  function: (identifier) @function.builtin
+  (#match? @function.builtin "^(?i)(abs|acos|addsoaprequestheader|addsoapresponseheader|aigetmetadata|aihas|ajaxlink|ajaxonload|applicationpathcacheclear|applicationstarttime|applicationstop|argon2checkhash|array|arrayappend|arrayavg|arrayclear|arraycontains|arraycontainsnocase|arraydelete|arraydeleteat|arraydeletenocase|arrayeach|arrayevery|arrayfilter|arrayfind|arrayfindall|arrayfindallnocase|arrayfindnocase|arrayfirst|arrayindexexists|arrayinsertat|arrayisdefined|arrayisempty|arraylast|arraylen|arraymap|arraymax|arraymedian|arraymerge|arraymid|arraymin|arraynew|arraypop|arrayprepend|arraypush|arrayreduce|arrayremoveduplicates|arrayresize|arrayreverse|arrayset|arrayshift|arrayslice|arraysome|arraysort|arraysplice|arraysum|arrayswap|arraytolist|arraytostruct|arrayunshift|asc|asin|astfrompath|astfromstring|atn|beat|binarydecode|binaryencode|bitand|bitmaskclear|bitmaskread|bitmaskset|bitnot|bitor|bitshln|bitshrn|bitxor|booleanformat|bundleinfo|cacheclear|cachecount|cachedelete|cacheget|cachegetall|cachegetallids|cachegetdefaultcachename|cachegetmetadata|cachegetproperties|cacheidexists|cachekeyexists|cacheput|cacheregionexists|cacheregionnew|cacheregionremove|cacheremove|cacheremoveall|cachesetproperties|callstackdump|callstackget|canonicalize|ceiling|cfusion_decrypt|cfusion_encrypt|charsetdecode|charsetencode|chr|cjustify|cleartimezone|collectioneach|collectionevery|collectionfilter|collectionmap|collectionreduce|collectionsome|compare|comparenocase|componentcacheclear|componentcachelist|componentinfo|componentlistpackage|compress|configimport|configtranslate|contractpath|cos|createaisession|createdate|createdatetime|createdynamicproxy|createguid|createobject|createodbcdate|createodbcdatetime|createodbctime|createtime|createtimespan|createulid|createuniqueid|createuuid|createwebsocketclient|csrfgeneratetoken|csrfverifytoken|ctcacheclear|ctcachelist|datasourceflushmetacache|dateadd|datecompare|dateconvert|datediff|dateformat|datepart|datetimeformat|day|dayofweek|dayofweekasstring|dayofweekshortasstring|dayofyear|daysinmonth|daysinyear|dbpoolclear|de|debugadd|decimalformat|decodeforhtml|decodefromurl|decrementvalue|decrypt|decryptbinary|deleteclientvariable|deserializejson|directorycopy|directorycreate|directorydelete|directoryexists|directoryinfo|directorylist|directoryrename|dollarformat|dump|duplicate|each|ec2describeinstances|echo|empty|encodeforcss|encodefordn|encodeforhtml|encodeforhtmlattribute|encodeforjavascript|encodeforldap|encodeforsql|encodeforurl|encodeforxml|encodeforxmlattribute|encodeforxpath|encrypt|encryptbinary|entitydelete|entityload|entityloadbyexample|entityloadbypk|entitymerge|entitynamearray|entitynamelist|entitynew|entityreload|entitysave|entitytoquery|esapidecode|esapiencode|evaluate|exp|expandpath|extensionexists|extensioninfo|extensionlist|extract|fileappend|fileclose|filecopy|filedelete|fileexists|filegetmimetype|fileinfo|fileiseof|filemodetosymbolic|filemove|fileopen|fileread|filereadbinary|filereadline|fileseek|filesetaccessmode|filesetattribute|filesetlastmodified|fileskipbytes|filetouch|fileupload|fileuploadall|filewrite|filewriteline|find|findlast|findlastnocase|findnocase|findoneof|firstdayofmonth|fix|floor|formatbasen|gatewayaction|gatewaystate|generate3deskey|generateargon2hash|generatepbkdfkey|generatersakeys|generatesecretkey|getapplicationmetadata|getapplicationsettings|getauthuser|getbasetagdata|getbasetaglist|getbasetemplatepath|getbuiltinfunction|getcanonicalpath|getclasspath|getclientvariableslist|getcomponentmetadata|getcomponentstaticscope|getcontextinfo|getcontextroot|getcpuusage|getcurrentcontext|getcurrenttemplatepath|getdirectoryfrompath|getencoding|getfilefrompath|getfileinfo|getfreespace|getfunctioncalledname|getfunctiondata|getfunctionkeywords|getfunctionlist|gethttprequestdata|gethttprequestheaders|gethttptimestring|getk2serverdoccount|getk2serverdoccountlimit|getlocale|getlocaledisplayname|getlocaleinfo|getlocalhostip|getluceeid|getmemoryusage|getmetadata|getmetricdata|getnumericdate|getpagecontext|getprinterinfo|getprinterlist|getprofilesections|getprofilestring|getpropertyfile|getpropertystring|getreadableimageformats|getsoaprequest|getsoaprequestheader|getsoapresponse|getsoapresponseheader|getsystemfreememory|getsystemmetrics|getsystemproporenvvar|getsystemtotalmemory|gettagdata|gettaglist|gettempdirectory|gettempfile|gettemplatepath|gettickcount|gettimezone|gettimezoneinfo|gettoken|gettotalspace|getuserroles|getvariable|getvfsmetadata|getwriteableimageformats|guarddecode|guardencode|hash|hash40|hmac|hour|htmlcodeformat|htmleditformat|htmlparse|iif|imageaddborder|imageblur|imagecaptcha|imageclearrect|imagecoderinfo|imagecopy|imagecrop|imagedrawarc|imagedrawbeveledrect|imagedrawcubiccurve|imagedrawimage|imagedrawline|imagedrawlines|imagedrawoval|imagedrawpoint|imagedrawquadraticcurve|imagedrawrect|imagedrawroundrect|imagedrawtext|imagefilter|imagefiltercolormap|imagefiltercurves|imagefilterkernel|imagefilterwarpgrid|imageflip|imagefonts|imageformats|imagegetblob|imagegetbufferedimage|imagegetexifmetadata|imagegetexiftag|imagegetheight|imagegetiptcmetadata|imagegetwidth|imagegrayscale|imageinfo|imagenegative|imagenew|imageoverlay|imagepaste|imageread|imagereadbase64|imageresize|imagerotate|imagerotatedrawingaxis|imagescaletofit|imagesetantialiasing|imagesetbackgroundcolor|imagesetdrawingalpha|imagesetdrawingcolor|imagesetdrawingstroke|imagesetdrawingtransparency|imagesharpen|imageshear|imagesheardrawingaxis|imagetranslate|imagetranslatedrawingaxis|imagewrite|imagewritebase64|imagewritetobrowser|imagexordrawingmode|incrementvalue|inputbasen|inquiryaisession|insert|inspecttemplates|int|internalrequest|interruptthread|invoke|isarray|isbinary|isboolean|isclosure|iscustomfunction|isdate|isdebugmode|isdefined|isempty|isfileobject|isflushed|isimage|isimagefile|isinstanceof|isinthread|isipinrange|isipv6|isjson|isleapyear|islocalhost|isnotmap|isnull|isnumeric|isnumericdate|isobject|ispdfobject|isquery|issimplevalue|issoaprequest|isstruct|isthreadinterrupted|isuserinanyrole|isuserinrole|isuserloggedin|isvalid|isvideofile|iswddx|iswithintransaction|isxml|isxmlattribute|isxmldoc|isxmlelem|isxmlnode|isxmlroot|iszipfile|javacast|jsstringformat|lcase|left|len|listappend|listavg|listchangedelims|listcompact|listcontains|listcontainsnocase|listdeleteat|listeach|listevery|listfilter|listfind|listfindnocase|listfirst|listgetat|listgetduplicates|listindexexists|listinsertat|listitemtrim|listlast|listlen|listmap|listprepend|listqualifiedtoarray|listqualify|listreduce|listremoveduplicates|listrest|listsetat|listsome|listsort|listtoarray|listtrim|listvaluecount|listvaluecountnocase|ljustify|loadaisession|location|log|log10|logallthreads|lscurrencyformat|lsdateformat|lsdatetimeformat|lsdayofweek|lseurocurrencyformat|lsiscurrency|lsisdate|lsisnumeric|lslcase|lsnumberformat|lsparsecurrency|lsparsedatetime|lsparseeurocurrency|lsparsenumber|lstimeformat|lsucase|lsweek|ltrim|luceeaigetmetadata|luceeaihas|luceecreateaisession|luceeinquiryaisession|manifestread|markdowntohtml|maveninfo|mavenload|max|metaphone|mid|millisecond|min|minute|month|monthasstring|monthshortasstring|newline|now|nowserver|nullvalue|numberformat|objectequals|objectload|objectsave|ormclearsession|ormcloseallsessions|ormclosesession|ormevictcollection|ormevictentity|ormevictqueries|ormexecutequery|ormflush|ormgetsession|ormgetsessionfactory|ormreload|pagepoolclear|pagepoollist|paragraphformat|parameterexists|parsedatetime|parsenumber|pi|precisionevaluate|preservesinglequotes|quarter|query|queryaddcolumn|queryaddrow|queryappend|queryclear|queryclose|querycolumnarray|querycolumncount|querycolumndata|querycolumnexists|querycolumnlist|queryconvertforgrid|querycurrentrow|querydeletecolumn|querydeleterow|queryeach|queryevery|queryexecute|queryfilter|querygetcell|querygetcellbyindex|querygetrow|queryinsertat|queryisempty|querykeyexists|querylazy|querymap|querynew|queryprepend|queryrecordcount|queryreduce|queryrenamecolumn|queryreverse|queryrowbyindex|queryrowdata|queryrowdatabyindex|queryrowswap|querysetcell|querysetrow|queryslice|querysome|querysort|querytostruct|quotedvaluelist|rand|randomize|randrange|rediscommand|rediscommandlowpriority|redisconnectionpoolinfo|reescape|refind|refindnocase|releasecomobject|rematch|rematchnocase|removechars|render|repeatstring|replace|replacelist|replacelistnocase|replacenocase|rereplace|rereplacenocase|restdeleteapplication|restinitapplication|restsetresponse|reverse|right|rjustify|round|rtrim|runasync|s3addacl|s3clearbucket|s3copy|s3createbucket|s3delete|s3deletebucket|s3download|s3exists|s3generatepresignedurl|s3generateuri|s3getacl|s3getmetadata|s3getversioninfo|s3listbucket|s3listbuckets|s3move|s3read|s3readbinary|s3setacl|s3setmetadata|s3upload|s3write|sanitize|sanitizehtml|second|secretproviderget|sendgatewaymessage|serialize|serializeaisession|serializejson|sessioncommit|sessionexists|sessioninvalidate|sessionrotate|sessionstarttime|setencoding|setlocale|setprofilestring|setpropertystring|settimezone|setvariable|sgn|sin|sizeof|sleep|soundex|spanexcluding|spanincluding|spreadsheetnew|sqr|sslcertificateinstall|sslcertificatelist|storeaddacl|storegetacl|storegetmetadata|storesetacl|storesetmetadata|stringeach|stringevery|stringfilter|stringlen|stringmap|stringreduce|stringsome|stringsort|stripcr|structappend|structclear|structcopy|structcount|structdelete|structeach|structevery|structfilter|structfind|structfindkey|structfindvalue|structget|structinsert|structisempty|structkeyarray|structkeyexists|structkeylist|structkeytranslate|structmap|structnew|structreduce|structsome|structsort|structtosorted|structupdate|structvaluearray|systemcacheclear|systemoutput|tan|threaddata|threadinterrupt|threadinterrupted|threadjoin|threadterminate|throw|timeformat|tobase64|tobinary|tonumeric|toscript|tostring|trace|transactioncommit|transactionrollback|transactionsetsavepoint|trim|trimwhitespace|truefalseformat|ucase|ucfirst|unserializejava|urldecode|urlencode|urlencodedformat|urlsessionformat|val|validatejson|valuearray|valuelist|valueref|verifyclient|webservicenew|websocketinfo|week|wrap|writedump|writelog|writeoutput|xmlchildpos|xmlelemnew|xmlformat|xmlgetnodetype|xmlnew|xmlparse|xmlsearch|xmltransform|xmlvalidate|year|yesnoformat)$"))
+
+; Function and method calls
 (call_expression
   function: (identifier) @function.call)
 
@@ -73,6 +104,7 @@
   (#eq? @variable.builtin "self"))
 
 (this) @variable.builtin
+
 (super) @variable.builtin
 
 (cf_var) @keyword
@@ -96,9 +128,11 @@
   (#match? @comment.documentation "^/[*][*][^*].*[*]/$"))
 
 (string) @string
+
 (hash_empty) @punctuation.special
 
 (regex_pattern) @string.regexp
+
 (regex_flags) @character.special
 
 (regex
@@ -110,6 +144,9 @@
   "#" @punctuation.special)
 
 (unary_operator) @operator
+
+(spread_element
+  "..." @operator)
 
 ((identifier) @number
   (#any-of? @number "NaN" "Infinity"))
@@ -178,6 +215,12 @@
   "&&="
   "||="
   "??="
+  "<="
+  "<>"
+  "<<"
+  ">="
+  ">>"
+  ">>>"
 ] @operator
 
 [
@@ -204,6 +247,8 @@
   "instanceof"
   "static"
   "with"
+  "default"
+  "in"
 ] @keyword
 
 [
@@ -213,6 +258,7 @@
   "]"
   "{"
   "}"
+  "</"
 ] @punctuation.bracket
 
 ; SQL keywords and identifiers
@@ -224,6 +270,7 @@
 (query_function_name) @variable
 
 (query_identifier) @variable
+
 (query_alias
   right: _ @variable)
 
@@ -239,13 +286,25 @@
 (query_comparison_expression
   operator: _ @operator)
 
-(quoted_query_value
-  (query_value) @string)
-(double_quoted_query_value
-  (query_value) @string)
+; Quoted values: capture the whole node so the delimiters are styled too
+[
+  (quoted_query_value)
+  (double_quoted_query_value)
+] @string
+
+; Backticks and brackets quote an identifier, not a string literal
+(backtick_quoted_query_value
+  (query_value) @variable)
+
+(backtick_quoted_query_value
+  "`" @punctuation.bracket)
 
 (query_comma) @punctuation.delimiter
+
 (query_semicolon) @punctuation.delimiter
+
+(bracketed_query_value
+  (query_value) @variable)
 
 (bracketed_query_value
   ["[" "]"] @punctuation.bracket)
@@ -259,4 +318,14 @@
 (query_operator) @operator
 
 (query_open_paren) @punctuation.bracket
+
 (query_close_paren) @punctuation.bracket
+
+(quoted_query_value
+  (query_value) @string)
+
+(double_quoted_query_value
+  (query_value) @string)
+
+; Lucee object selector, e.g. `new java:java.io.File(...)`
+(type_prefix) @keyword

--- a/cfscript/queries/highlights.scm
+++ b/cfscript/queries/highlights.scm
@@ -1,26 +1,30 @@
 ; Variables
 ;----------
-
 (identifier) @variable
 
 ; CFML scopes
 ;-------------
-
 ((identifier) @variable.builtin
  (#match? @variable.builtin "^(?i)(APPLICATION|ARGUMENTS|CGI|CLIENT|COOKIE|FORM|LOCAL|REQUEST|SERVER|SESSION|THIS|URL|VARIABLES)$"))
 
 ; Properties
 ;-----------
-
 (property_identifier) @property
+
 (shorthand_property_identifier) @property
+
+(shorthand_property_identifier_pattern) @property
+
 (private_property_identifier) @property
 
 ; Component and property declarations
 ;-------------------------------------
-
 (component_attribute
   (attribute_label) @attribute)
+
+; Namespaced attributes, e.g. `component test:displayLabel="..."`
+(component_attribute
+  ":" @punctuation.delimiter)
 
 (property_declaration
   name: (identifier) @property)
@@ -30,13 +34,15 @@
 
 ; Function and method definitions
 ;--------------------------------
-
 (function_expression
   name: (identifier) @function)
+
 (function_declaration
   name: (identifier) @function)
+
 (function_declaration
   (access_type) @keyword)
+
 (method_definition
   name: (property_identifier) @function.method)
 
@@ -74,7 +80,6 @@
 
 ; Special identifiers
 ;--------------------
-
 ((identifier) @constructor
  (#match? @constructor "^[A-Z]"))
 
@@ -95,9 +100,10 @@
 
 ; Literals
 ;---------
-
 (this) @variable.builtin
+
 (super) @variable.builtin
+
 (undefined) @constant.builtin
 
 [
@@ -108,7 +114,11 @@
 ] @constant.builtin
 
 (comment) @comment
+
 (cf_comment) @comment
+
+((comment) @comment.documentation
+  (#match? @comment.documentation "^/[*][*][^*].*[*]/$"))
 
 [
   (string)
@@ -117,14 +127,20 @@
 
 (hash_expression
   "#" @punctuation.special)
+
 (hash_empty) @punctuation.special
 
-(regex) @string.special
+(regex_pattern) @string.regexp
+
+(regex_flags) @character.special
+
+(regex
+  "/" @punctuation.bracket) ; Regex delimiters
+
 (number) @number
 
 ; Tokens
 ;-------
-
 [
   ";"
   (optional_chain)
@@ -136,8 +152,28 @@
 (ordered_struct
   ["[" ":" "]"] @punctuation.bracket)
 
+(pair
+  ":" @punctuation.delimiter)
+
+(pair_pattern
+  ":" @punctuation.delimiter)
+
+(switch_case
+  ":" @punctuation.delimiter)
+
+(switch_default
+  ":" @punctuation.delimiter)
+
+(labeled_statement
+  ":" @punctuation.delimiter)
+
+(slice_expression
+  ":" @punctuation.delimiter)
+
 (cfml_template
   "```" @punctuation.delimiter)
+
+(cfml_template_content) @embedded
 
 (ternary_expression
   [
@@ -150,28 +186,38 @@
 
 ; Types
 ;------
-
 (parameter_type) @type
-; `User[] function getUsers()` — one token, so the anonymous "[" / "]"
-; rule below cannot reach it.
-(array_return_suffix) @punctuation.bracket
+
 (catch_clause
   type: (catch_type) @type)
 
+(property_declaration
+  type: [(identifier) (path)] @type)
+
 ; Tag statements
 ;---------------
-
 (tag_statement
   tag: (identifier) @keyword)
+
 (query_tag
   "query" @keyword)
 
+; Inline queries
+;---------------
+
+; Unparented so the keyword stays highlighted mid-typing, while the string is still
+; unterminated and the whole call sits inside an ERROR node.
+"queryExecute" @function.builtin
+
+(query_expression
+  ["\"" "'"] @punctuation.delimiter)
+
+(query_text) @embedded
+
 ; Imports
 ;--------
-
 (import_path
   (identifier) @module)
-
 
 [
   "-"
@@ -215,7 +261,13 @@
   "&&="
   "||="
   "??="
+  "<>"
+  "<<"
+  ">>"
+  ">>>"
 ] @operator
+
+(unary_operator) @operator
 
 [
   "("
@@ -267,4 +319,18 @@
   "void"
   "while"
   "with"
+  "abstract"
+  "final"
+  "interface"
+  "property"
+  "required"
 ] @keyword
+
+(regex) @string.special
+
+; `User[] function getUsers()` — one token, so the anonymous "[" / "]"
+; rule below cannot reach it.
+(array_return_suffix) @punctuation.bracket
+
+; Lucee object selector, e.g. `new java:java.io.File(...)`
+(type_prefix) @keyword


### PR DESCRIPTION
[zed-cfml](https://github.com/cfmleditor/zed-cfml) carries a remapped copy of these
queries, and its versions had moved ahead. An audit there measured coverage against
**this repo's own test corpus** and closed every gap it found. This ports those rules
back so the two stop diverging.

## Approach

For every rule present in both repos, this emits **this repo's text verbatim**, so the
capture vocabulary here is untouched — `@variable.builtin`, `@comment.documentation`,
`@string.regexp`, `@character.special`, `@text`. Only genuinely new rules get a mapped
name.

That distinction matters: the Zed → nvim-treesitter direction is lossy, because Zed
folds `@function.call`, `@function.method` and `@function.method.call` all into
`@function`. A blind reverse remap would corrupt them. None of the ported rules hit that
case.

Rules only in this repo are preserved (`array_return_suffix`, `->`), and the operator
and keyword lists are merged item-wise rather than replaced.

## What changes

**cfml**
- CDATA sections, `cfsavecontent` tag delimiters
- `hash_single` — the `#` delimiters of a bare `#var#` in a tag body are their own node,
  so the `hash_expression` rule never reached them
- `shorthand_property_identifier_pattern`
- built-in function list was 166 functions behind cfscript's

**cfscript**
- `unary_operator`, so `!`, `~` and Lucee's `NOT` are covered by one rule
- colons in switch cases, struct pairs, slices, labels and namespaced component
  attributes — six different nodes produce one
- regex split into pattern / flags / delimiters; docblock comments
- `queryExecute` and its `query_text`; `cfml_template_content`
- `abstract`, `final`, `interface`, `property`, `required` keywords

**cfquery**
- CFML scopes and Lucee built-ins, neither of which it had, though both are reachable
  through `#...#` expressions
- quoted values capture the whole node so delimiters are styled; backtick- and
  bracket-quoted values are identifiers, not strings
- `cfoutput` / `cfreturn` tag delimiters, spread operator

**All three**
- `<=`, `>=`, `<>`, `<<`, `>>`, `>>>`
- `type_prefix` for `new java:java.io.File(...)`, which neither repo covered

## Verification

Each grammar's test corpus was replayed and every leaf token diffed against the ranges
the queries capture, with parsers built from `master`:

| | snippets | leaf tokens | uncaptured |
|---|---|---|---|
| cfml | 112 | 5,134 | **0** |
| cfscript | 134 | 4,228 | **0** |
| cfquery | 72 | 1,734 | **0** |

`queryExecute` is intentionally unparented: an unterminated string collapses the
statement into one `ERROR` node, so a rule keyed on `query_expression` stops matching
exactly while the call is being typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)