### PR TITLE
Highlight parameter_type and array_return_suffix in cfquery

### DIFF
--- a/cfquery/queries/highlights.scm
+++ b/cfquery/queries/highlights.scm
@@ -327,5 +327,11 @@
 (double_quoted_query_value
   (query_value) @string)
 
+; Reachable inside `#...#` through a `function(...)` expression or a typed
+; arrow-function parameter, even though a `<cfscript>` block is not.
+(parameter_type) @type
+; `User[] v` - one token, so the anonymous "[" / "]" rule cannot reach it.
+(array_return_suffix) @punctuation.bracket
+
 ; Lucee object selector, e.g. `new java:java.io.File(...)`
 (type_prefix) @keyword


### PR DESCRIPTION
Follow-up to #64, which merged before this commit was pushed.

Both nodes were left out of cfquery on the reasoning that `<cfscript>` is a parse error
inside a cfquery body, so nothing script-shaped could be reachable there. The premise is
true and the conclusion does not follow — the shared expression grammar reaches cfquery
through `#...#`, and a function *expression* is an expression:

```
SELECT #f( function( string[] v ) { return v; } )#
```

parses cleanly, with `parameter_type` and `array_return_suffix` both present and no
`ERROR` node. Verified by parsing rather than by reasoning from the tag.

Credit to `claude/tree-sitter-cfml-update-tikpro`, which found this. Its `type_prefix`
rule arrived with #64, so these two rules were all that was outstanding; that branch is
now fully subsumed and can be deleted.

Worth noting the coverage checker did not catch this either — no snippet in the cfquery
corpus has that shape, and it only finds what the corpus exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)