### PR TITLE
Highlight the three query gaps the v0.26.32/33 nodes left

### DIFF
--- a/cfml/queries/highlights.scm
+++ b/cfml/queries/highlights.scm
@@ -189,6 +189,9 @@
 ; `User[] function getUsers()` — one token, so the anonymous "[" / "]"
 ; rule below cannot reach it.
 (array_return_suffix) @punctuation.bracket
+; `new java:X()` / `new cfml:X()` — one token including the colon, and a
+; fixed pair of words, so it belongs with the `new` keyword beside it.
+(type_prefix) @keyword
 (catch_clause
   type: (catch_type) @type)
 

--- a/cfquery/queries/highlights.scm
+++ b/cfquery/queries/highlights.scm
@@ -180,6 +180,19 @@
   "??="
 ] @operator
 
+; Types
+;------
+
+; Reachable inside `#...#` through a `function(…)` expression or a typed
+; arrow-function parameter, even though a `<cfscript>` block is not.
+(parameter_type) @type
+; `User[] v` — one token, so the anonymous "[" / "]" rule above cannot reach it.
+(array_return_suffix) @punctuation.bracket
+
+; `new java:X()` / `new cfml:X()` — one token including the colon, and a
+; fixed pair of words, so it belongs with the `new` keyword beside it.
+(type_prefix) @keyword
+
 [
   "var"
   "let"

--- a/cfscript/queries/highlights.scm
+++ b/cfscript/queries/highlights.scm
@@ -155,6 +155,9 @@
 ; `User[] function getUsers()` — one token, so the anonymous "[" / "]"
 ; rule below cannot reach it.
 (array_return_suffix) @punctuation.bracket
+; `new java:X()` / `new cfml:X()` — one token including the colon, and a
+; fixed pair of words, so it belongs with the `new` keyword beside it.
+(type_prefix) @keyword
 (catch_clause
   type: (catch_type) @type)
 


### PR DESCRIPTION
`type_prefix` (`new java:X()` / `new cfml:X()`) shipped in v0.26.33 with no highlight rule at all, so the prefix rendered unstyled beside the `new` keyword it belongs with. It is one token including the colon and a fixed pair of words, so it takes `@keyword`.

cfquery was also missing `parameter_type` and `array_return_suffix`. The standing assumption was that anything script-shaped is unreachable there because `<cfscript>` is a parse error inside a cfquery body — but the shared expression grammar still reaches it through `#...#`, and `#f( function( string[] v ) { … } )#` parses with both nodes present. Verified by parsing rather than by reasoning from the tag.

zed-cfml's coverage checker reports 0 uncaptured tokens across all three grammars again with these in place.