### PR TITLE
Pin tree-sitter-cli to 0.27.0, so the intended upgrade actually applies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "globals": "^17.12.0",
         "prebuildify": "^6.0.1",
         "tree-sitter": "0.25.1",
-        "tree-sitter-cli": "0.27.-"
+        "tree-sitter-cli": "0.27.0"
       },
       "engines": {
         "node": ">=18 <=24"
@@ -1386,9 +1386,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.26.13",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.26.13.tgz",
-      "integrity": "sha512-SIC74lxT2jsygxaIGGb50Bpf8jtll24aXju98Y3eJienBTXCRQ+5k3YigwN31pASEUZKcKh98EPSZWky7ugUMA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.27.0.tgz",
+      "integrity": "sha512-E42kR0og1mFlZBxPj7K4fBXCTjxPTGe19U9RXGWNq0FQKzXOxIp8bhCYFMKhddiVZUsJwW35MYGU9Q1oVYtpbA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "globals": "^17.12.0",
     "prebuildify": "^6.0.1",
     "tree-sitter": "0.25.1",
-    "tree-sitter-cli": "0.27.-"
+    "tree-sitter-cli": "0.27.0"
   },
   "overrides": {
     "eslint-plugin-jsdoc": "^62.9.0"


### PR DESCRIPTION
`bfef61f` set the pin to `0.27.-`, which is not a valid semver range.

## The effect is quieter than it looks

Worth stating precisely so it is neither over- nor under-read. `package-lock.json` recorded the requested range as `0.27.-` **and** a resolution of `0.26.13`, so npm treated the two files as in sync. `npm ci` succeeded, `npm install` succeeded, and **CI was never broken** — I initially thought otherwise and was wrong.

What did not happen is the upgrade. The repo said 0.27 in `package.json` while every build, local and CI, kept using **0.26.13**.

It does fail for anyone resolving without the lockfile — deleting the lock, or a consumer resolving the range:

```
no lockfile, "0.27.-"   npm install -> exit 1   npm error code ETARGET
                                                No matching version found for tree-sitter-cli@0.27.-
no lockfile, "0.27.0"   npm install -> exit 0
```

`0.27.0` is the only 0.27 release and is `latest`. The exact pin (no caret) matches how `tree-sitter` itself is pinned in the same block.

## The upgrade is a no-op for generated output

This is the result worth recording, and the risk that did not materialise. Regenerating all three grammars with 0.27.0 produces a **zero diff** under `cf*/src/`:

| | ABI | `STATE_COUNT` |
|---|---|---|
| `cfml` | 15 (unchanged) | 5494 (unchanged) |
| `cfquery` | 15 (unchanged) | 4152 (unchanged) |
| `cfscript` | 15 (unchanged) | 5272 (unchanged) |

So no parser regeneration is needed, and no open PR has to rebase for a table change — the usual hazard of a tree-sitter CLI bump in a repo that commits its generated parsers.

## Verification

| check | result |
|---|---|
| `npm run build` (all three) | pass, **zero diff** under `cf*/src/` |
| `npm test` | pass |
| `npm run probe` | pass (42/50) |
| `npm run lint` | pass |
| `npm run testbindings` | pass |
| `npm run fuzz` | pass |
| `scripts/check-generated.js` | no drift |

Two files changed: `package.json` and `package-lock.json`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3JjZSaiDNzZVg866si8Gj

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3JjZSaiDNzZVg866si8Gj)_