### PR TITLE
cfml: capture access_type as @keyword [ai]

### DIFF
--- a/cfml/queries/highlights.scm
+++ b/cfml/queries/highlights.scm
@@ -94,7 +94,7 @@
   name: (identifier) @function)
 
 (function_declaration
-  (access_type) @access_type)
+  (access_type) @keyword)
 
 (method_definition
   name: [


### PR DESCRIPTION
`(access_type) @access_type` is not a capture name any highlighter styles, so `public` /
`private` / `remote` / `package` on a `cffunction` rendered unstyled.

cfscript and cfquery already use `@keyword` for the same node — cfml was the outlier:

| | capture |
|---|---|
| `cfml/queries/highlights.scm:97` | `@access_type` ← |
| `cfscript/queries/highlights.scm:44` | `@keyword` |
| `cfquery/queries/highlights.scm:56` | `@keyword` |

This class of bug is invisible to a coverage check, which only asks whether a token is
captured, not whether the capture name means anything downstream.

zed-cfml had patched it locally, but its query files are synced down from here, so the
fix was reverted by every `cargo xtask update-grammar`. Fixing it at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)