### PR TITLE
docs: correct two stale corpus figures in CLAUDE.md and LIMITATIONS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Three layers, each catching what the one above misses:
 
 - `cf*/test/corpus/` — the committed expectations. `npm test` runs them.
 - `test/probes/` — minimal reductions of constructs found in real code, with their current pass/fail status in `test/probes/expected.json`. `npm run probe` fails on drift **in either direction**, so a gap closing is as visible as a regression.
-- the real-world corpus (`npm run corpus:fetch`) — 14,974 files from public CFML projects, kept in `~/corpus` when that exists. Not in CI; run it by hand before and after a grammar change and diff the two scans. Three changes in the last round looked self-contained, passed the test suite, and were only caught here.
+- the real-world corpus (`npm run corpus:fetch`) — 15,083 files from public CFML projects, kept in `~/corpus` when that exists. Not in CI; run it by hand before and after a grammar change and diff the two scans. Three changes in the last round looked self-contained, passed the test suite, and were only caught here.
 
 ### Bindings (`bindings/`)
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -130,7 +130,7 @@ with bare reserved words.
 
 `<cfprocessingdirective>` can be used with or without a body. When used without a closing tag, the grammar treats it as a paired tag and consumes content until EOF or another implicit close trigger. Use self-closing syntax (`/>`) for bodyless usage.
 
-`<cfsetting>` is now a void tag — `</cfsetting>` never appears in the 12,549-file corpus, while `<cfsetting …>` appears 336 times — so it no longer swallows the rest of the template.
+`<cfsetting>` is now a void tag — `</cfsetting>` never appears in the 15,083-file corpus, while `<cfsetting …>` appears 417 times — so it no longer swallows the rest of the template.
 
 ### Dynamic tag names not fully evaluated
 


### PR DESCRIPTION
Found while checking whether the `FAILING-PATTERNS.md` refresh (#111) left its siblings behind. It had — two files carried **current-tense** claims about the corpus, where a stale number reads as fact rather than as history.

| file | said | is |
|---|---|---|
| `CLAUDE.md` | corpus is **14,974** files | **15,083** |
| `LIMITATIONS.md` | *"`</cfsetting>` never appears in the **12,549**-file corpus, while `<cfsetting …>` appears **336** times"* | **15,083** / **417** |

## The `<cfsetting>` claim was re-verified, not just renumbered

That figure is load-bearing — it's the evidence for `<cfsetting>` being treated as a void tag — so I re-ran it against the current corpus rather than scaling the old number:

```
</cfsetting>    0 occurrences
<cfsetting …>   417 occurrences
```

The reasoning holds exactly as written; only the evidence figures had drifted.

## Deliberately not touched

`CORPUS.md` also reads 12,549, in this table:

```
Scanned on `master` (v0.26.30), on `claude/keyword-casing-and-test-harness` …

| | `master` | casing branch | this branch |
| Files scanned | 12,549 | 12,549 | 12,549 |
```

That one is explicitly dated and is a record of a past measurement. Updating it would **falsify history rather than refresh it** — the distinction being whether a number describes today or describes a moment. Left alone on purpose.

Also checked and found clean: `docs/TODO.md` (no stale issue references), and every `LIMITATIONS.md` entry for an issue closed this round is already marked fixed. The two entries still describing #80 as open are correct — [#107](https://github.com/cfmleditor/tree-sitter-cfml/pull/107) is parked and unmerged, and carries those edits.

Docs only. `npm test` and `npm run lint` pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3JjZSaiDNzZVg866si8Gj

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3JjZSaiDNzZVg866si8Gj)_